### PR TITLE
microsoft sentinel update

### DIFF
--- a/Deploy/GrantPermissions.ps1
+++ b/Deploy/GrantPermissions.ps1
@@ -35,27 +35,27 @@ function Set-RBACPermissions ($MSIName, $Role) {
 
 #UEBA
 Set-APIPermissions -MSIName $UEBALogicAppName -AppId "ca7f3f0b-7d91-482c-8e09-c5d840d0eac5" -PermissionName "Data.Read"
-Set-RBACPermissions -MSIName $UEBALogicAppName -Role "Azure Sentinel Responder"
+Set-RBACPermissions -MSIName $UEBALogicAppName -Role "Microsoft Sentinel Responder"
 
 #OOF
 Set-APIPermissions -MSIName $OOFLogicAppName -AppId "00000003-0000-0000-c000-000000000000" -PermissionName "MailboxSettings.Read"
-Set-RBACPermissions -MSIName $OOFLogicAppName -Role "Azure Sentinel Responder"
+Set-RBACPermissions -MSIName $OOFLogicAppName -Role "Microsoft Sentinel Responder"
 
 #RelatedAlerts
 Set-APIPermissions -MSIName $RelatedAlertsLogicAppName -AppId "ca7f3f0b-7d91-482c-8e09-c5d840d0eac5" -PermissionName "Data.Read"
-Set-RBACPermissions -MSIName $RelatedAlertsLogicAppName -Role "Azure Sentinel Responder"
+Set-RBACPermissions -MSIName $RelatedAlertsLogicAppName -Role "Microsoft Sentinel Responder"
 
 #MDE
 Set-APIPermissions -MSIName $MDELogicAppName -AppId "00000003-0000-0000-c000-000000000000" -PermissionName "User.Read.All"
 Set-APIPermissions -MSIName $MDELogicAppName -AppId "fc780465-2017-40d4-a0c5-307022471b92" -PermissionName "AdvancedQuery.Read.All"
 Set-APIPermissions -MSIName $MDELogicAppName -AppId "fc780465-2017-40d4-a0c5-307022471b92" -PermissionName "Machine.Read.All"
-Set-RBACPermissions -MSIName $MDELogicAppName -Role "Azure Sentinel Responder"
+Set-RBACPermissions -MSIName $MDELogicAppName -Role "Microsoft Sentinel Responder"
 
 #MCAS
 Set-APIPermissions -MSIName $MCASLogicAppName -AppId "00000003-0000-0000-c000-000000000000" -PermissionName "User.Read.All"
-Set-RBACPermissions -MSIName $MCASLogicAppName -Role "Azure Sentinel Responder"
+Set-RBACPermissions -MSIName $MCASLogicAppName -Role "Microsoft Sentinel Responder"
 
 #Watchlists
 Set-APIPermissions -MSIName $WatchlistLogicAppName -AppId "ca7f3f0b-7d91-482c-8e09-c5d840d0eac5" -PermissionName "Data.Read"
-Set-RBACPermissions -MSIName $WatchlistLogicAppName -Role "Azure Sentinel Responder"
+Set-RBACPermissions -MSIName $WatchlistLogicAppName -Role "Microsoft Sentinel Responder"
 

--- a/Deploy/createUiDefinition.json
+++ b/Deploy/createUiDefinition.json
@@ -6,7 +6,7 @@
         "config": {
             "isWizard": true,
             "basics": {
-                "description": "Azure Sentinel Automaiton Modules Solution Deployment",
+                "description": "Microsoft Sentinel Triage AssistanT (STAT) Deployment",
                 "location": {
                     "label": "Location",
                     "toolTip": "Location for all resources",

--- a/Modules/AADRisksModule/GrantPermissions.ps1
+++ b/Modules/AADRisksModule/GrantPermissions.ps1
@@ -32,4 +32,4 @@ function Set-RBACPermissions ($MSIName, $Role) {
 Set-APIPermissions -MSIName $RelatedAlertsLogicAppName -AppId "ca7f3f0b-7d91-482c-8e09-c5d840d0eac5" -PermissionName "Data.Read"
 Set-APIPermissions -MSIName $RelatedAlertsLogicAppName -AppId "00000003-0000-0000-c000-000000000000" -PermissionName "User.Read.All"
 Set-APIPermissions -MSIName $RelatedAlertsLogicAppName -AppId "00000003-0000-0000-c000-000000000000" -PermissionName "IdentityRiskyUser.Read.All"
-Set-RBACPermissions -MSIName $RelatedAlertsLogicAppName -Role "Azure Sentinel Responder"
+Set-RBACPermissions -MSIName $RelatedAlertsLogicAppName -Role "Microsoft Sentinel Responder"

--- a/Modules/AADRisksModule/readme.md
+++ b/Modules/AADRisksModule/readme.md
@@ -75,4 +75,4 @@ Trigger name: **triage**
 * Grant the Logic app managed identity access to the Log Analytics API application permissions Data.Read (GrantPermissions.ps1)
 * Grant the Logic app managed identity access to the Microsoft Graph application permissions User.Read.All (GrantPermissions.ps1)
 * Grant the Logic app managed identity access to the Microsoft Graph application permissions IdentityRiskyUser.Read.All (GrantPermissions.ps1)
-* Grant the Logic app Azure Sentinel Responder RBAC role on the resource group containing Azure Sentinel (GrantPermissions.ps1)
+* Grant the Logic app Microsoft Sentinel Responder RBAC role on the resource group containing Microsoft Sentinel (GrantPermissions.ps1)

--- a/Modules/BaseModule/GrantPermissions.ps1
+++ b/Modules/BaseModule/GrantPermissions.ps1
@@ -30,4 +30,3 @@ function Set-RBACPermissions ($MSIName, $Role) {
 #Enrich-Entities
 Set-APIPermissions -MSIName $SharedLogicAppName -AppId "00000003-0000-0000-c000-000000000000" -PermissionName "User.Read.All"
 Set-APIPermissions -MSIName $SharedLogicAppName -AppId "00000003-0000-0000-c000-000000000000" -PermissionName "RoleManagement.Read.Directory"
-Set-RBACPermissions -MSIName $SharedLogicAppName -Role "Azure Sentinel Responder"

--- a/Modules/BaseModule/readme.md
+++ b/Modules/BaseModule/readme.md
@@ -135,4 +135,3 @@ The base module must be called before any other modules in this solution.  It pe
 ## Post Deployment
 
 * Grant the Logic app managed identity access to the Microsoft Graph application permissions User.Read.All and RoleManagement.Read.Directory (GrantPermissions.ps1)
-* Grant the Logic app Azure Sentinel Responder RBAC role on the resource group containing Azure Sentinel (GrantPermissions.ps1)

--- a/Modules/FileModule/GrantPermissions.ps1
+++ b/Modules/FileModule/GrantPermissions.ps1
@@ -30,4 +30,4 @@ function Set-RBACPermissions ($MSIName, $Role) {
 
 #FileInsights
 Set-APIPermissions -MSIName $FileLogicAppName -AppId "8ee8fdad-f234-4243-8f3b-15c294843740" -PermissionName "AdvancedHunting.Read.All"
-Set-RBACPermissions -MSIName $FileLogicAppName -Role "Azure Sentinel Responder"
+Set-RBACPermissions -MSIName $FileLogicAppName -Role "Microsoft Sentinel Responder"

--- a/Modules/FileModule/readme.md
+++ b/Modules/FileModule/readme.md
@@ -87,4 +87,4 @@ Trigger name: **triage**
 ## Post Deployment
 
 * Grant the Logic app managed identity access to the Microsoft Threat Protection permissions AdvancedHunting.Read.All (GrantPermissions.ps1)
-* Grant the Logic app Azure Sentinel Responder RBAC role on the resource group containing Azure Sentinel (GrantPermissions.ps1)
+* Grant the Logic app Microsoft Sentinel Responder RBAC role on the resource group containing Microsoft Sentinel (GrantPermissions.ps1)

--- a/Modules/MCASModule/GrantPermissions.ps1
+++ b/Modules/MCASModule/GrantPermissions.ps1
@@ -29,4 +29,4 @@ function Set-RBACPermissions ($MSIName, $Role) {
 }
 
 #MCAS
-Set-RBACPermissions -MSIName $MCASLogicAppName -Role "Azure Sentinel Responder"
+Set-RBACPermissions -MSIName $MCASLogicAppName -Role "Microsoft Sentinel Responder"

--- a/Modules/MCASModule/readme.md
+++ b/Modules/MCASModule/readme.md
@@ -62,7 +62,7 @@ If you do not perform these tasks before the deployement, you can leave the defa
 
 ## Post Deployment
 
-- Grant the Logic App managed identity the Azure Sentinel Responder RBAC role on the resource group containing Azure Sentinel. (GrantPermissions.ps1)
+- Grant the Logic App managed identity the Microsoft Sentinel Responder RBAC role on the resource group containing Microsoft Sentinel. (GrantPermissions.ps1)
 
 ## Additional Links
 * [Understand the investigation priority score](https://docs.microsoft.com/en-us/cloud-app-security/tutorial-ueba#understand-the-investigation-priority-score)

--- a/Modules/MDEModule/GrantPermissions.ps1
+++ b/Modules/MDEModule/GrantPermissions.ps1
@@ -32,4 +32,4 @@ function Set-RBACPermissions ($MSIName, $Role) {
 Set-APIPermissions -MSIName $MDELogicAppName -AppId "00000003-0000-0000-c000-000000000000" -PermissionName "User.Read.All"
 Set-APIPermissions -MSIName $MDELogicAppName -AppId "fc780465-2017-40d4-a0c5-307022471b92" -PermissionName "AdvancedQuery.Read.All"
 Set-APIPermissions -MSIName $MDELogicAppName -AppId "fc780465-2017-40d4-a0c5-307022471b92" -PermissionName "Machine.Read.All"
-Set-RBACPermissions -MSIName $MDELogicAppName -Role "Azure Sentinel Responder"
+Set-RBACPermissions -MSIName $MDELogicAppName -Role "Microsoft Sentinel Responder"

--- a/Modules/MDEModule/readme.md
+++ b/Modules/MDEModule/readme.md
@@ -86,4 +86,4 @@ This module will return the risk score and exposure level from Microsoft Defende
 
 * Grant the Logic app managed identity access to the Microsoft Graph application permissions User.Read.All (GrantPermissions.ps1)
 * Grant the Logic app managed identity access to the Microsoft Defender API permissions Machine.Read.All and AdvancedQuery.Read.All (GrantPermissions.ps1)
-* Grant the Logic app Azure Sentinel Responder RBAC role on the resource group containing Azure Sentinel (GrantPermissions.ps1)
+* Grant the Logic app Microsoft Sentinel Responder RBAC role on the resource group containing Microsoft Sentinel (GrantPermissions.ps1)

--- a/Modules/OOFModule/GrantPermissions.ps1
+++ b/Modules/OOFModule/GrantPermissions.ps1
@@ -30,4 +30,4 @@ function Set-RBACPermissions ($MSIName, $Role) {
 
 #OOF
 Set-APIPermissions -MSIName $OOFLogicAppName -AppId "00000003-0000-0000-c000-000000000000" -PermissionName "MailboxSettings.Read"
-Set-RBACPermissions -MSIName $OOFLogicAppName -Role "Azure Sentinel Responder"
+Set-RBACPermissions -MSIName $OOFLogicAppName -Role "Microsoft Sentinel Responder"

--- a/Modules/OOFModule/readme.md
+++ b/Modules/OOFModule/readme.md
@@ -46,4 +46,4 @@ This module will check the incidient entities to see if a user is out of the off
 ## Post Deployment
 
 * Grant the Logic app managed identity access to the Microsoft Graph application permissions MailboxSettings.Read (GrantPermissions.ps1)
-* Grant the Logic app Azure Sentinel Responder RBAC role on the resource group containing Azure Sentinel (GrantPermissions.ps1)
+* Grant the Logic app Microsoft Sentinel Responder RBAC role on the resource group containing Microsoft Sentinel (GrantPermissions.ps1)

--- a/Modules/RelatedAlerts/GrantPermissions.ps1
+++ b/Modules/RelatedAlerts/GrantPermissions.ps1
@@ -30,4 +30,4 @@ function Set-RBACPermissions ($MSIName, $Role) {
 
 #RelatedAlerts
 Set-APIPermissions -MSIName $RelatedAlertsLogicAppName -AppId "ca7f3f0b-7d91-482c-8e09-c5d840d0eac5" -PermissionName "Data.Read"
-Set-RBACPermissions -MSIName $RelatedAlertsLogicAppName -Role "Azure Sentinel Responder"
+Set-RBACPermissions -MSIName $RelatedAlertsLogicAppName -Role "Microsoft Sentinel Responder"

--- a/Modules/RelatedAlerts/readme.md
+++ b/Modules/RelatedAlerts/readme.md
@@ -79,4 +79,4 @@ This module will check the incidient entities to see if there are any other aler
 ## Post Deployment
 
 * Grant the Logic app managed identity access to the Log Analytics API application permissions Data.Read (GrantPermissions.ps1)
-* Grant the Logic app Azure Sentinel Responder RBAC role on the resource group containing Azure Sentinel (GrantPermissions.ps1)
+* Grant the Logic app Microsoft Sentinel Responder RBAC role on the resource group containing Microsoft Sentinel (GrantPermissions.ps1)

--- a/Modules/UEBAModule/GrantPermissions.ps1
+++ b/Modules/UEBAModule/GrantPermissions.ps1
@@ -30,4 +30,4 @@ function Set-RBACPermissions ($MSIName, $Role) {
 
 #UEBA
 Set-APIPermissions -MSIName $UEBALogicAppName -AppId "ca7f3f0b-7d91-482c-8e09-c5d840d0eac5" -PermissionName "Data.Read"
-Set-RBACPermissions -MSIName $UEBALogicAppName -Role "Azure Sentinel Responder"
+Set-RBACPermissions -MSIName $UEBALogicAppName -Role "Microsoft Sentinel Responder"

--- a/Modules/UEBAModule/readme.md
+++ b/Modules/UEBAModule/readme.md
@@ -62,4 +62,4 @@ This module will check the incident account entities to see if there are any Use
 ## Post Deployment
 
 * Grant the Logic app managed identity access to the Log Analytics API application permissions Data.Read (GrantPermissions.ps1)
-* Grant the Logic app Azure Sentinel Responder RBAC role on the resource group containing Azure Sentinel (GrantPermissions.ps1)
+* Grant the Logic app Microsoft Sentinel Responder RBAC role on the resource group containing Microsoft Sentinel (GrantPermissions.ps1)

--- a/Modules/WatchlistModule/GrantPermissions.ps1
+++ b/Modules/WatchlistModule/GrantPermissions.ps1
@@ -30,4 +30,4 @@ function Set-RBACPermissions ($MSIName, $Role) {
 
 #Watchlists
 Set-APIPermissions -MSIName $WatchlistLogicAppName -AppId "ca7f3f0b-7d91-482c-8e09-c5d840d0eac5" -PermissionName "Data.Read"
-Set-RBACPermissions -MSIName $WatchlistLogicAppName -Role "Azure Sentinel Responder"
+Set-RBACPermissions -MSIName $WatchlistLogicAppName -Role "Microsoft Sentinel Responder"

--- a/Modules/WatchlistModule/readme.md
+++ b/Modules/WatchlistModule/readme.md
@@ -52,4 +52,4 @@ This module will check the incident entities to see if there are any matches on 
 ## Post Deployment
 
 * Grant the Logic app managed identity access to the Log Analytics API application permissions Data.Read (GrantPermissions.ps1)
-* Grant the Logic app Azure Sentinel Responder RBAC role on the resource group containing Azure Sentinel (GrantPermissions.ps1)
+* Grant the Logic app Microsoft Sentinel Responder RBAC role on the resource group containing Microsoft Sentinel (GrantPermissions.ps1)

--- a/Modules/readme.md
+++ b/Modules/readme.md
@@ -7,9 +7,9 @@ Automation Modules make it easier to perform routine tasks by using a common set
 * Microsoft Cloud App Security
 * Microsoft Defender for Endpoint
 * Office 365 Out of Office
-* Azure Sentinel Related Alerts
-* Azure Sentinel User Entity Behavior Analytics
-* Azure Sentinel Watchlists
+* Microsoft Sentinel Related Alerts
+* Microsoft Sentinel User Entity Behavior Analytics
+* Microsoft Sentinel Watchlists
 
 ### Microsoft Cloud App Security
 
@@ -23,14 +23,14 @@ Module Description
 
 The Out Of Office module takes user entity data and determines if the user has an Out of Office message set on their Office 365 mailbox.
 
-### Azure Sentinel Related Alerts
+### Microsoft Sentinel Related Alerts
 
-The Related Alerts module takes the incident entity data and determines if other alerts about those same entities exist in Azure Sentinel within a specified timeframe.
+The Related Alerts module takes the incident entity data and determines if other alerts about those same entities exist in Microsoft Sentinel within a specified timeframe.
 
-### Azure Sentinel User Entity Behavior Analytics
+### Microsoft Sentinel User Entity Behavior Analytics
 
 The UEBA module allows you to take user entity data and lookup those users in the BehaviorAnalytics table to identity activities performed by the user that deviate from their previous patterns of behavior.
 
-### Azure Sentinel Watchlists
+### Microsoft Sentinel Watchlists
 
-The Azure Sentinel Watchlists module allows you to compare entity data from an incident against a watchlist to determine if that entity is present.  This supports watchlists containing columns with UserPrincipalNames, IP Addresses, or CIDR address blocks.
+The Microsoft Sentinel Watchlists module allows you to compare entity data from an incident against a watchlist to determine if that entity is present.  This supports watchlists containing columns with UserPrincipalNames, IP Addresses, or CIDR address blocks.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # Sentinel Triage AssistanT (STAT) :hospital:
 
-The Microsoft Sentinel Triage AssistanT (STAT) is a library of callable Automation [Modules](/Modules/readme.md) that can be used from Incident based Azure Sentinel playbooks.  These modules will simplify automation by moving the complex tasks into these callable modules so they can be performed consistently and with ease from a parent playbook.
+The Microsoft Sentinel Triage AssistanT (STAT) is a library of callable Automation [Modules](/Modules/readme.md) that can be used from Incident based Microsoft Sentinel playbooks.  These modules will simplify automation by moving the complex tasks into these callable modules so they can be performed consistently and with ease from a parent playbook.
 
 The Base Module prepares and enriches Incident and entity data for each of the triage modules which consumes this data and performs analysis against the entities related to the incident the automation is triaging.  These triage modules will return a easy to use, well documented schema so you can evaluate the outputs and quickly make decisions about how to handle an incident.
 
 Project goals include:
 
-* Reducing the time (and cost) of building Azure Sentinel Automation
-* Reducing the time to test Azure Sentinel Automation through the use of consistent callable modules
+* Reducing the time (and cost) of building Microsoft Sentinel Automation
+* Reducing the time to test Microsoft Sentinel Automation through the use of consistent callable modules
 * Increasing SOC efficiency by triaging Incidents before they reach an analyst
 
-Many of the Azure Sentinel playbook templates available today focus on Notification, Incident Enrichment and Remediation.  This project focuses on the triage and analysis of an incident to provide additional confidence in the quality of the incident before taking actions.  When the incident is determined to be low quality (likely a benign positive), it can be closed or lowered in severity through these automation flows.  When the incident is determined to be of higher quality, it can be raised in severity, assigned to an analyst or even trigger a remediation task.
+Many of the Microsoft Sentinel playbook templates available today focus on Notification, Incident Enrichment and Remediation.  This project focuses on the triage and analysis of an incident to provide additional confidence in the quality of the incident before taking actions.  When the incident is determined to be low quality (likely a benign positive), it can be closed or lowered in severity through these automation flows.  When the incident is determined to be of higher quality, it can be raised in severity, assigned to an analyst or even trigger a remediation task.
 
 The full solution is available for deployment in the [Deployment](/Deploy/readme.md) section.  Please note there is no stable release currently available for this project.  This is an early build of this solution and is subject to bugs and significant change as we work to provide an initial preview release.

--- a/Samples/readme.md
+++ b/Samples/readme.md
@@ -9,4 +9,4 @@ This Playbook shows an example of how to use multiple automation modules togethe
 
 ## Post Deployment
 
-* Grant the Logic app Azure Sentinel Responder RBAC role on the resource group containing Azure Sentinel
+* Grant the Logic app Microsoft Sentinel Responder RBAC role on the resource group containing Microsoft Sentinel


### PR DESCRIPTION
With the change from Azure Sentinel -> Microsoft Sentinel all of the permissions delegations have started to fail due to the RBAC role no longer being found

Fixes #122 