### PR TITLE
adding addiitonal error handling

### DIFF
--- a/Modules/OOFModule/azuredeploy.json
+++ b/Modules/OOFModule/azuredeploy.json
@@ -8,7 +8,8 @@
         }
     },
     "variables": {
-        "AzureSentinelConnectionName": "[concat('azuresentinel-', parameters('PlaybookName'))]"
+        "AzureSentinelConnectionName": "[concat('azuresentinel-', parameters('PlaybookName'))]",
+        "ConversionServiceConnectionName": "[concat('conversionservice-', parameters('PlaybookName'))]"
     },
     "resources": [
         {
@@ -27,12 +28,27 @@
             }
         },
         {
+            "type": "Microsoft.Web/connections",
+            "apiVersion": "2016-06-01",
+            "name": "[variables('ConversionServiceConnectionName')]",
+            "location": "[resourceGroup().location]",
+            "kind": "V1",
+            "properties": {
+                "displayName": "[variables('ConversionServiceConnectionName')]",
+                "customParameterValues": {},
+                "api": {
+                    "id": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', resourceGroup().location, '/managedApis/conversionservice')]"
+                }
+            }
+        },
+        {
             "type": "Microsoft.Logic/workflows",
             "apiVersion": "2017-07-01",
             "name": "[parameters('PlaybookName')]",
             "location": "[resourceGroup().location]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/connections', variables('AzureSentinelConnectionName'))]"
+                "[resourceId('Microsoft.Web/connections', variables('AzureSentinelConnectionName'))]",
+                "[resourceId('Microsoft.Web/connections', variables('ConversionServiceConnectionName'))]"
             ],
             "identity": {
                 "type": "SystemAssigned"
@@ -202,7 +218,8 @@
                         "Filter_array_-_OOF_Disabled": {
                             "runAfter": {
                                 "For_each": [
-                                    "Succeeded"
+                                    "Succeeded",
+                                    "Failed"
                                 ]
                             },
                             "type": "Query",
@@ -214,7 +231,8 @@
                         "Filter_array_-_OOF_Enabled": {
                             "runAfter": {
                                 "For_each": [
-                                    "Succeeded"
+                                    "Succeeded",
+                                    "Failed"
                                 ]
                             },
                             "type": "Query",
@@ -226,7 +244,8 @@
                         "Filter_array_-_OOF_Unknown": {
                             "runAfter": {
                                 "For_each": [
-                                    "Succeeded"
+                                    "Succeeded",
+                                    "Failed"
                                 ]
                             },
                             "type": "Query",
@@ -249,8 +268,10 @@
                                     "inputs": {
                                         "name": "DetailedResults",
                                         "value": {
+                                            "ExternalMessage": "",
+                                            "InternalMessage": "",
                                             "OOFStatus": "unknown",
-                                            "UPN": "@{items('For_each')?['userPrincipalName']}"
+                                            "UPN": "@{coalesce(items('For_each')?['userPrincipalName'],items('For_each')?['RawEntity']?['friendlyName'])}"
                                         }
                                     }
                                 },
@@ -277,16 +298,52 @@
                                             "case": "alwaysEnabled",
                                             "actions": {
                                                 "Append_to_DetailedResults_-_alwaysEnabled": {
-                                                    "runAfter": {},
+                                                    "runAfter": {
+                                                        "Html_to_text_-_internal": [
+                                                            "Succeeded"
+                                                        ]
+                                                    },
                                                     "type": "AppendToArrayVariable",
                                                     "inputs": {
                                                         "name": "DetailedResults",
                                                         "value": {
-                                                            "ExternalMessage": "@{body('HTTP')['externalReplyMessage']}",
-                                                            "InternalMessage": "@{body('HTTP')['internalReplyMessage']}",
+                                                            "ExternalMessage": "@{take(body('Html_to_text_-_external'), 600)}",
+                                                            "InternalMessage": "@{take(body('Html_to_text_-_internal'), 600)}",
                                                             "OOFStatus": "enabled",
                                                             "UPN": "@{items('For_each')?['userPrincipalName']}"
                                                         }
+                                                    }
+                                                },
+                                                "Html_to_text_-_external": {
+                                                    "runAfter": {},
+                                                    "type": "ApiConnection",
+                                                    "inputs": {
+                                                        "body": "<p>@{body('HTTP')['externalReplyMessage']}</p>",
+                                                        "host": {
+                                                            "connection": {
+                                                                "name": "@parameters('$connections')['conversionservice']['connectionId']"
+                                                            }
+                                                        },
+                                                        "method": "post",
+                                                        "path": "/html2text"
+                                                    }
+                                                },
+                                                "Html_to_text_-_internal": {
+                                                    "runAfter": {
+                                                        "Html_to_text_-_external": [
+                                                            "Succeeded"
+                                                        ]
+                                                    },
+                                                    "type": "ApiConnection",
+                                                    "inputs": {
+                                                        "body": "<p>@{body('HTTP')['internalReplyMessage']}</p>",
+                                                        "host": {
+                                                            "connection": {
+                                                                "name": "@parameters('$connections')['conversionservice']['connectionId']"
+                                                            }
+                                                        },
+                                                        "method": "post",
+                                                        "path": "/html2text"
                                                     }
                                                 }
                                             }
@@ -313,16 +370,52 @@
                                             "case": "enabled",
                                             "actions": {
                                                 "Append_to_DetailedResults_-_enabled": {
-                                                    "runAfter": {},
+                                                    "runAfter": {
+                                                        "Html_to_text_-_internal_enabled": [
+                                                            "Succeeded"
+                                                        ]
+                                                    },
                                                     "type": "AppendToArrayVariable",
                                                     "inputs": {
                                                         "name": "DetailedResults",
                                                         "value": {
-                                                            "ExternalMessage": "@{body('HTTP')['externalReplyMessage']}",
-                                                            "InternalMessage": "@{body('HTTP')['internalReplyMessage']}",
+                                                            "ExternalMessage": "@{take(body('Html_to_text_-_external_enabled'), 600)}",
+                                                            "InternalMessage": "@{take(body('Html_to_text_-_internal_enabled'), 600)}",
                                                             "OOFStatus": "enabled",
                                                             "UPN": "@{items('For_each')?['userPrincipalName']}"
                                                         }
+                                                    }
+                                                },
+                                                "Html_to_text_-_external_enabled": {
+                                                    "runAfter": {},
+                                                    "type": "ApiConnection",
+                                                    "inputs": {
+                                                        "body": "<p>@{body('HTTP')['externalReplyMessage']}</p>",
+                                                        "host": {
+                                                            "connection": {
+                                                                "name": "@parameters('$connections')['conversionservice']['connectionId']"
+                                                            }
+                                                        },
+                                                        "method": "post",
+                                                        "path": "/html2text"
+                                                    }
+                                                },
+                                                "Html_to_text_-_internal_enabled": {
+                                                    "runAfter": {
+                                                        "Html_to_text_-_external_enabled": [
+                                                            "Succeeded"
+                                                        ]
+                                                    },
+                                                    "type": "ApiConnection",
+                                                    "inputs": {
+                                                        "body": "<p>@{body('HTTP')['internalReplyMessage']}</p>",
+                                                        "host": {
+                                                            "connection": {
+                                                                "name": "@parameters('$connections')['conversionservice']['connectionId']"
+                                                            }
+                                                        },
+                                                        "method": "post",
+                                                        "path": "/html2text"
                                                     }
                                                 }
                                             }
@@ -333,16 +426,52 @@
                                                 "Condition": {
                                                     "actions": {
                                                         "Append_to_array_variable_3": {
-                                                            "runAfter": {},
+                                                            "runAfter": {
+                                                                "Html_to_text_-_internal_scheduled": [
+                                                                    "Succeeded"
+                                                                ]
+                                                            },
                                                             "type": "AppendToArrayVariable",
                                                             "inputs": {
                                                                 "name": "DetailedResults",
                                                                 "value": {
-                                                                    "ExternalMessage": "@{body('HTTP')['externalReplyMessage']}",
-                                                                    "InternalMessage": "@{body('HTTP')['internalReplyMessage']}",
+                                                                    "ExternalMessage": "@{take(body('Html_to_text_-_external_scheduled'),600)}",
+                                                                    "InternalMessage": "@{take(body('Html_to_text_-_internal_scheduled'),600)}",
                                                                     "OOFStatus": "enabled",
                                                                     "UPN": "@{items('For_each')?['userPrincipalName']}"
                                                                 }
+                                                            }
+                                                        },
+                                                        "Html_to_text_-_external_scheduled": {
+                                                            "runAfter": {},
+                                                            "type": "ApiConnection",
+                                                            "inputs": {
+                                                                "body": "<p>@{body('HTTP')['externalReplyMessage']}</p>",
+                                                                "host": {
+                                                                    "connection": {
+                                                                        "name": "@parameters('$connections')['conversionservice']['connectionId']"
+                                                                    }
+                                                                },
+                                                                "method": "post",
+                                                                "path": "/html2text"
+                                                            }
+                                                        },
+                                                        "Html_to_text_-_internal_scheduled": {
+                                                            "runAfter": {
+                                                                "Html_to_text_-_external_scheduled": [
+                                                                    "Succeeded"
+                                                                ]
+                                                            },
+                                                            "type": "ApiConnection",
+                                                            "inputs": {
+                                                                "body": "<p>@{body('HTTP')['internalReplyMessage']}</p>",
+                                                                "host": {
+                                                                    "connection": {
+                                                                        "name": "@parameters('$connections')['conversionservice']['connectionId']"
+                                                                    }
+                                                                },
+                                                                "method": "post",
+                                                                "path": "/html2text"
                                                             }
                                                         }
                                                     },
@@ -833,6 +962,11 @@
                                         "type": "ManagedServiceIdentity"
                                     }
                                 }
+                            },
+                            "conversionservice": {
+                                "connectionId": "[resourceId('Microsoft.Web/connections', variables('ConversionServiceConnectionName'))]",
+                                "connectionName": "[variables('ConversionServiceConnectionName')]",
+                                "id": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', resourceGroup().location, '/managedApis/conversionservice')]"
                             }
                         }
                     }


### PR DESCRIPTION
Fixes #137 

This additional error handling for:
* If the base module cannot resolve the account it will not fail (return unknown status)
* if the account has no mailbox it will not fail (return unknown status)
* if the base module cannot resolve the account it will not set UPN to an empty string but rather the RawEntity.friendlyName instead
* if the out of office message is longer than 600 characters it is truncated to 600 to minimize the risk of hitting the comment limit
* removes html tags from the out of office message to reduce the character count and make it easier to read in a sentinel comment