### PR TITLE
Docs and Name update for Sample Playbook

### DIFF
--- a/Deploy/createUiDefinition.json
+++ b/Deploy/createUiDefinition.json
@@ -358,7 +358,7 @@
                         "type": "Microsoft.Common.TextBlock",
                         "visible": true,
                         "options": {
-                            "text": "The Basic Sample Playbook evaluates the incident entities to look for Related Alerts (Account, Host or IP), Threat Intelligence (Domain, FileHash, IP or URL) and Azure AD MFA Fraud reports.",
+                            "text": "The Basic Sample Playbook evaluates the incident entities to look for Related Alerts (Account, Host or IP), Threat Intelligence (Domain, FileHash, IP or URL) and Azure AD MFA Fraud reports. This sample demonstrates how STAT can be used to triage an incident and how the modules can work together. This sample is not meant to be capable of triaging any type of incident; additional playbooks may need to be built using STAT to handle the unique requirements of different incident types.",
                             "link": {
                                 "label": "Learn more",
                                 "uri": "https://github.com/briandelmsft/SentinelAutomationModules/tree/main/Samples"
@@ -379,7 +379,7 @@
                         "type": "Microsoft.Common.TextBox",
                         "label": "Basic Sample Triage Playbook Name",
                         "placeholder": "",
-                        "defaultValue": "Triage-RelatedContent",
+                        "defaultValue": "Sample-STAT-Triage",
                         "toolTip": "",
                         "constraints": {},
                         "visible": "[and(steps('sampleStep').DeployBasicSamplePlaybook,or(if(steps('automationModules').advancedSetup.DeployConnector, true, false), if(equals(steps('deploymentTypeStep').deploymentType, 'standard'), true, false)))]"
@@ -400,7 +400,7 @@
             "MCASPlaybookName": "[coalesce(steps('automationModules').advancedSetup.MCASPlaybookName,'Get-MCASInvestigationScore')]",
             "WatchlistPlaybookName": "[coalesce(steps('automationModules').advancedSetup.WatchlistPlaybookName,'Get-WatchlistInsights')]",
             "DeployBasicSamplePlaybook": "[steps('sampleStep').DeployBasicSamplePlaybook]",
-            "BasicSamplePlaybookName": "[coalesce(steps('sampleStep').BasicSamplePlaybookName,'Triage-RelatedContent')]",
+            "BasicSamplePlaybookName": "[coalesce(steps('sampleStep').BasicSamplePlaybookName,'Sample-STAT-Triage')]",
             "STATCoordinatorPlaybookName": "[coalesce(steps('automationModules').advancedSetup.STATCoordinatorPlaybookName,'STAT-Coordinator')]",
             "CustomConnectorName": "[coalesce(steps('automationModules').advancedSetup.CustomConnectorName,'SentinelTriageAssistant')]",
             "CustomConnectorDisplayName": "[coalesce(steps('automationModules').advancedSetup.CustomConnectorDisplayName,'Sentinel Triage AssistanT - STAT')]",

--- a/Docs/sample.md
+++ b/Docs/sample.md
@@ -1,10 +1,10 @@
 # Sentinel Triage AssistanT (STAT) :hospital: - Sample Playbook
 
-The Sample playbook is a Proof of Concept to demonstrate how STAT can be used to Triage an incident.
+The Sample playbook is a Proof of Concept to demonstrate how STAT can be used to Triage an incident. This sample is not meant to be capable of triaging any type of incident; additional playbooks may need to be built using STAT to handle the unique requirements of different incident types.
 
 The Playbook starts on a Sentinel Incident creation rule trigger and then starts the triage process using STAT:
 
-## Sample Logic
+## Sample Playbook Logic
 
 1. The STAT Base Module is called using the STAT Connector to enrich and prepare the entity data for the STAT Solution
 2. In parallel, the AAD Risks Module, Related Alerts Module and Threat Intel Module are called

--- a/Samples/basicsample.json
+++ b/Samples/basicsample.json
@@ -3,7 +3,7 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
         "PlaybookName": {
-            "defaultValue": "Triage-RelatedContent",
+            "defaultValue": "Sample-STAT-Triage",
             "type": "String"
         },
         "STAT_Connector_resourceId": {

--- a/Samples/readme.md
+++ b/Samples/readme.md
@@ -1,7 +1,7 @@
 # Sample Playbook
 
 ## Description
-This Playbook shows an example of how to use multiple automation modules together in order to triage an incident in Microsoft Sentinel.
+This Playbook shows an example of how to use multiple automation modules together in order to triage an incident in Microsoft Sentinel.  This sample is not meant to be capable of triaging any type of incident; additional playbooks may need to be built using STAT to handle the unique requirements of different incident types.
 
 ### Basic Sample
 


### PR DESCRIPTION
Documentation update and name update for sample playbook to reinforce that this is a sample of how STAT can be used, but that the sample is not meant to handle all incident types as is.  Related to #231

#231 still needs further investigation if the related alerts module needs an update to better handle fusion incidents 