### PR TITLE
MDEModule - add host support

### DIFF
--- a/Modules/MDEModule/azuredeploy.json
+++ b/Modules/MDEModule/azuredeploy.json
@@ -58,62 +58,17 @@
                 "state": "Enabled",
                 "definition": {
                     "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
-                    "contentVersion": "1.0.0.0",
-                    "parameters": {
-                        "$connections": {
-                            "defaultValue": {},
-                            "type": "Object"
-                        },
-                        "PlaybookVersion": {
-                            "defaultValue": "0.0.4",
-                            "type": "String"
-                        },
-                        "PlaybookInternalName": {
-                            "defaultValue": "MDEModule",
-                            "type": "String"
-                        },
-                        "ProjectName": {
-                            "defaultValue": "STAT",
-                            "type": "String"
-                        }
-                    },
-                    "triggers": {
-                        "triage": {
-                            "inputs": {
-                                "schema": {
-                                    "properties": {
-                                        "AddIncidentComments": {
-                                            "title": "Add comments to the incident",
-                                            "type": "boolean"
-                                        },
-                                        "Entities": {
-                                            "description": "Click here and select the EnrichedEntities object from the Dynamic content menu",
-                                            "title": "Enriched Entities",
-                                            "type": "array"
-                                        },
-                                        "LookbackInDays": {
-                                            "description": "Enter a value between 1 and 30",
-                                            "maximum": 30,
-                                            "minimum": 1,
-                                            "title": "Lookback period in days",
-                                            "type": "integer"
-                                        }
-                                    },
-                                    "type": "object"
-                                }
-                            },
-                            "kind": "Http",
-                            "type": "Request"
-                        }
-                    },
                     "actions": {
                         "Compose_response": {
                             "inputs": {
-                                "AnalyzedEntities": "@add(length(variables('DetailedResultsIPs')),length(variables('DetailedResultsAccounts')))",
+                                "AnalyzedEntities": "@add(length(variables('DetailedResultsHosts')),add(length(variables('DetailedResultsIPs')),length(variables('DetailedResultsAccounts'))))",
                                 "DetailedResults": {
                                     "Accounts": "@variables('DetailedResultsAccounts')",
+                                    "Hosts": "@variables('DetailedResultsHosts')",
                                     "IPs": "@variables('DetailedResultsIPs')"
                                 },
+                                "HostsHighestExposureLevel": "@{if(contains(body('Create_table_to_check_HostsHighestExposureLevel'), 'High'), 'High', if(contains(body('Create_table_to_check_HostsHighestExposureLevel'), 'Medium'), 'Medium', if(contains(body('Create_table_to_check_HostsHighestExposureLevel'), 'Low'), 'Low', if(contains(body('Create_table_to_check_HostsHighestExposureLevel'), 'None'),'None','Unknown'))))}",
+                                "HostsHighestRiskScore": "@{if(contains(body('Create_table_to_check_HostsHighestRiskScore'), 'High'), 'High', if(contains(body('Create_table_to_check_HostsHighestRiskScore'), 'Medium'), 'Medium', if(contains(body('Create_table_to_check_HostsHighestRiskScore'), 'Low'), 'Low', if(contains(body('Create_table_to_check_HostsHighestRiskScore'), 'Informational'), 'Informational', if(contains(body('Create_table_to_check_HostsHighestRiskScore'), 'None'), 'None', 'Unknown')))))}",
                                 "IPsHighestExposureLevel": "@{if(contains(body('Create_table_to_check_IPsHighestExposureLevel'), 'High'), 'High', if(contains(body('Create_table_to_check_IPsHighestExposureLevel'), 'Medium'), 'Medium', if(contains(body('Create_table_to_check_IPsHighestExposureLevel'), 'Low'), 'Low', if(contains(body('Create_table_to_check_IPsHighestExposureLevel'), 'None'),'None','Unknown'))))}",
                                 "IPsHighestRiskScore": "@{if(contains(body('Create_table_to_check_IPsHighestRiskScore'), 'High'), 'High', if(contains(body('Create_table_to_check_IPsHighestRiskScore'), 'Medium'), 'Medium', if(contains(body('Create_table_to_check_IPsHighestRiskScore'), 'Low'), 'Low', if(contains(body('Create_table_to_check_IPsHighestRiskScore'), 'Informational'), 'Informational', if(contains(body('Create_table_to_check_IPsHighestRiskScore'), 'None'), 'None', 'Unknown')))))}",
                                 "UsersHighestExposureLevel": "@{if(contains(body('Create_table_to_check_UsersHighestExposureLevel'), 'High'), 'High', if(contains(body('Create_table_to_check_UsersHighestExposureLevel'), 'Medium'), 'Medium', if(contains(body('Create_table_to_check_UsersHighestExposureLevel'), 'Low'), 'Low', if(contains(body('Create_table_to_check_UsersHighestExposureLevel'), 'None'),'None','Unknown'))))}",
@@ -121,6 +76,9 @@
                             },
                             "runAfter": {
                                 "Scope_Account": [
+                                    "Succeeded"
+                                ],
+                                "Scope_Host": [
                                     "Succeeded"
                                 ],
                                 "Scope_IP": [
@@ -135,7 +93,7 @@
                                     "inputs": {
                                         "body": {
                                             "incidentArmId": "@body('Parse_JSON')?['IncidentARMId']",
-                                            "message": "<p>Lookback in days: @{triggerBody()?['LookbackInDays']}</p><strong>Account Info</strong><br/><ul><li>Users Highest Risk Score: @{outputs('Compose_response')['UsersHighestRiskScore']}</li><li>Users Highest Exposure Level: @{outputs('Compose_response')['UsersHighestExposureLevel']}</li><li>List of users and devices: <ul>@{outputs('Compose_UserDevices_output')}</ul></li></ul><strong>IP Info</strong><br/><br/><ul><li>IP Highest Risk Score: @{outputs('Compose_response')['IPsHighestRiskScore']}</li><li>IP Highest Exposure Level: @{outputs('Compose_response')['IPsHighestExposureLevel']}</li><li>List of IP and devices: <ul>@{variables('Comments')}</ul></li></ul>"
+                                            "message": "Lookback in days: @{triggerBody()?['LookbackInDays']}<br/><ul><li>Users Highest Risk Score: @{outputs('Compose_response')['UsersHighestRiskScore']}</li><li>Users Highest Exposure Level: @{outputs('Compose_response')['UsersHighestExposureLevel']}</li></ul>@{outputs('Compose_UserDevices_output')}<br/><ul><li>IP Highest Risk Score: @{outputs('Compose_response')['IPsHighestRiskScore']}</li><li>IP Highest Exposure Level: @{outputs('Compose_response')['IPsHighestExposureLevel']}</li></ul>@{outputs('Compose_IPDevices_output')}<br/><ul><li>Host Highest Risk Score: @{outputs('Compose_response')['HostsHighestRiskScore']}</li><li>Host Highest Exposure Level: @{outputs('Compose_response')['HostsHighestExposureLevel']}</li></ul>@{variables('Comments')}"
                                         },
                                         "host": {
                                             "connection": {
@@ -146,11 +104,20 @@
                                         "path": "/Incidents/Comment"
                                     },
                                     "runAfter": {
-                                        "For_each_DetailedResultsIPs": [
+                                        "For_each_DetailedResultsHosts": [
                                             "Succeeded"
                                         ]
                                     },
                                     "type": "ApiConnection"
+                                },
+                                "Compose_IPDevices_output": {
+                                    "inputs": "@variables('Comments')",
+                                    "runAfter": {
+                                        "For_each_DetailedResultsIPs": [
+                                            "Succeeded"
+                                        ]
+                                    },
+                                    "type": "Compose"
                                 },
                                 "Compose_UserDevices_output": {
                                     "inputs": "@variables('Comments')",
@@ -166,7 +133,7 @@
                                         "Append_to_string_variable_Comments": {
                                             "inputs": {
                                                 "name": "Comments",
-                                                "value": "<li>@{if(not(equals(item()['UserPrincipalName'], '')), item()['UserPrincipalName'], item()['UserSid'])} @{if(equals(length(items('For_each_DetailedResultsAccounts')['UserDevices']),0),' - No devices found',body('Create_HTML_table_for_UserDevices'))}</li>"
+                                                "value": "@{if(not(equals(item()['UserPrincipalName'], '')), item()['UserPrincipalName'], item()['UserSid'])} @{if(equals(length(items('For_each_DetailedResultsAccounts')['UserDevices']),0),' - No devices found',body('Create_HTML_table_for_UserDevices'))}"
                                             },
                                             "runAfter": {
                                                 "Create_HTML_table_for_UserDevices": [
@@ -193,12 +160,43 @@
                                     },
                                     "type": "Foreach"
                                 },
+                                "For_each_DetailedResultsHosts": {
+                                    "actions": {
+                                        "Append_to_string_variable_Comments_a_last_time": {
+                                            "inputs": {
+                                                "name": "Comments",
+                                                "value": "@if(equals(length(items('For_each_DetailedResultsHosts')['Hosts']),0),' - No hosts found',body('Create_HTML_table_for_Hosts'))"
+                                            },
+                                            "runAfter": {
+                                                "Create_HTML_table_for_Hosts": [
+                                                    "Succeeded"
+                                                ]
+                                            },
+                                            "type": "AppendToStringVariable"
+                                        },
+                                        "Create_HTML_table_for_Hosts": {
+                                            "inputs": {
+                                                "format": "HTML",
+                                                "from": "@items('For_each_DetailedResultsHosts')['Hosts']"
+                                            },
+                                            "runAfter": {},
+                                            "type": "Table"
+                                        }
+                                    },
+                                    "foreach": "@variables('DetailedResultsHosts')",
+                                    "runAfter": {
+                                        "Reset_variable_Comments_again": [
+                                            "Succeeded"
+                                        ]
+                                    },
+                                    "type": "Foreach"
+                                },
                                 "For_each_DetailedResultsIPs": {
                                     "actions": {
                                         "Append_to_string_variable_Comments_again": {
                                             "inputs": {
                                                 "name": "Comments",
-                                                "value": "<li>@{items('For_each_DetailedResultsIPs')['Address']}@{if(equals(length(items('For_each_DetailedResultsIPs')['IPDevices']),0),' - No devices found',body('Create_HTML_table_for_IPDevices'))}</li>"
+                                                "value": "@{items('For_each_DetailedResultsIPs')['Address']}@{if(equals(length(items('For_each_DetailedResultsIPs')['IPDevices']),0),' - No devices found',body('Create_HTML_table_for_IPDevices'))}"
                                             },
                                             "runAfter": {
                                                 "Create_HTML_table_for_IPDevices": [
@@ -210,7 +208,7 @@
                                         "Create_HTML_table_for_IPDevices": {
                                             "inputs": {
                                                 "format": "HTML",
-                                                "from": "@item()['IPDevices']"
+                                                "from": "@items('For_each_DetailedResultsIPs')['IPDevices']"
                                             },
                                             "runAfter": {},
                                             "type": "Table"
@@ -236,6 +234,18 @@
                                     },
                                     "runAfter": {
                                         "Compose_UserDevices_output": [
+                                            "Succeeded"
+                                        ]
+                                    },
+                                    "type": "SetVariable"
+                                },
+                                "Reset_variable_Comments_again": {
+                                    "inputs": {
+                                        "name": "Comments",
+                                        "value": "@{null}"
+                                    },
+                                    "runAfter": {
+                                        "Compose_IPDevices_output": [
                                             "Succeeded"
                                         ]
                                     },
@@ -266,6 +276,8 @@
                                         "body": {
                                             "AnalyzedEntities": 0,
                                             "DetailedResults": [],
+                                            "DevicesHighestExposureLevel": "Unknown",
+                                            "DevicesHighestRiskScore": "Unknown",
                                             "IPsHighestExposureLevel": "Unknown",
                                             "IPsHighestRiskScore": "Unknown",
                                             "UsersHighestExposureLevel": "Unknown",
@@ -302,6 +314,12 @@
                                             "@body('Parse_JSON')?['IPsCount']",
                                             0
                                         ]
+                                    },
+                                    {
+                                        "equals": [
+                                            "@body('Parse_JSON')?['HostsCount']",
+                                            0
+                                        ]
                                     }
                                 ]
                             },
@@ -322,7 +340,7 @@
                                 ]
                             },
                             "runAfter": {
-                                "Initialize_variable_DetailedResultsIPs": [
+                                "Initialize_variable_DetailedResultsHosts": [
                                     "Succeeded"
                                 ]
                             },
@@ -340,6 +358,23 @@
                             },
                             "runAfter": {
                                 "Parse_JSON": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "type": "InitializeVariable"
+                        },
+                        "Initialize_variable_DetailedResultsHosts": {
+                            "inputs": {
+                                "variables": [
+                                    {
+                                        "name": "DetailedResultsHosts",
+                                        "type": "array",
+                                        "value": []
+                                    }
+                                ]
+                            },
+                            "runAfter": {
+                                "Initialize_variable_DetailedResultsIPs": [
                                     "Succeeded"
                                 ]
                             },
@@ -772,6 +807,27 @@
                             },
                             "type": "Response"
                         },
+                        "Response_error_Host": {
+                            "inputs": {
+                                "body": {
+                                    "Error": "@{parameters('PlaybookInternalName')} failed to execute with status @{result('For_each_host')[0]['outputs'][0]['outputs']['statusCode']}",
+                                    "PlaybookName": "@{workflow()?['name']}",
+                                    "PlaybookResourceId": "@{workflow()?['id']}",
+                                    "PlaybookRunId": "@{workflow()?['run']?['name']}",
+                                    "PlaybookVersion": "@parameters('PlaybookVersion')",
+                                    "SourceError": "@result('For_each_host')[0]['outputs'][0]['outputs']['body']"
+                                },
+                                "statusCode": "@result('For_each_host')[0]['outputs'][0]['outputs']['statusCode']"
+                            },
+                            "kind": "http",
+                            "runAfter": {
+                                "Scope_Host": [
+                                    "TIMEDOUT",
+                                    "FAILED"
+                                ]
+                            },
+                            "type": "Response"
+                        },
                         "Response_error_IP": {
                             "inputs": {
                                 "body": {
@@ -959,6 +1015,128 @@
                             },
                             "type": "Scope"
                         },
+                        "Scope_Host": {
+                            "actions": {
+                                "Create_table_to_check_HostsHighestExposureLevel": {
+                                    "inputs": {
+                                        "columns": [
+                                            {
+                                                "header": "",
+                                                "value": "@item()['HostHighestExposureLevel']"
+                                            }
+                                        ],
+                                        "format": "CSV",
+                                        "from": "@variables('DetailedResultsHosts')"
+                                    },
+                                    "runAfter": {
+                                        "Create_table_to_check_HostsHighestRiskScore": [
+                                            "Succeeded"
+                                        ]
+                                    },
+                                    "type": "Table"
+                                },
+                                "Create_table_to_check_HostsHighestRiskScore": {
+                                    "inputs": {
+                                        "columns": [
+                                            {
+                                                "header": "",
+                                                "value": "@item()['HostHighestRiskScore']"
+                                            }
+                                        ],
+                                        "format": "CSV",
+                                        "from": "@variables('DetailedResultsHosts')"
+                                    },
+                                    "runAfter": {
+                                        "For_each_host": [
+                                            "Succeeded"
+                                        ]
+                                    },
+                                    "type": "Table"
+                                },
+                                "For_each_host": {
+                                    "actions": {
+                                        "Append_to_array_variable_DetailedResultsHosts": {
+                                            "inputs": {
+                                                "name": "DetailedResultsHosts",
+                                                "value": {
+                                                    "HostHighestExposureLevel": "@{if(contains(body('Create_table_to_check_HostHighestExposureLevel'), 'High'), 'High', if(contains(body('Create_table_to_check_HostHighestExposureLevel'), 'Medium'), 'Medium', if(contains(body('Create_table_to_check_HostHighestExposureLevel'), 'Low'), 'Low', if(contains(body('Create_table_to_check_HostHighestExposureLevel'), 'None'),'None','Unknown'))))}",
+                                                    "HostHighestRiskScore": "@{if(contains(body('Create_table_to_check_HostHighestRiskScore'), 'High'), 'High', if(contains(body('Create_table_to_check_HostHighestRiskScore'), 'Medium'), 'Medium', if(contains(body('Create_table_to_check_HostHighestRiskScore'), 'Low'), 'Low', if(contains(body('Create_table_to_check_HostHighestRiskScore'), 'Informational'), 'Informational', if(contains(body('Create_table_to_check_HostHighestRiskScore'), 'None'), 'None', 'Unknown')))))}",
+                                                    "Hosts": "@body('Machines_-_Get_list_of_machines_-_Host_path')?['value']"
+                                                }
+                                            },
+                                            "runAfter": {
+                                                "Create_table_to_check_HostHighestExposureLevel": [
+                                                    "Succeeded"
+                                                ]
+                                            },
+                                            "type": "AppendToArrayVariable"
+                                        },
+                                        "Create_table_to_check_HostHighestExposureLevel": {
+                                            "inputs": {
+                                                "columns": [
+                                                    {
+                                                        "header": "",
+                                                        "value": "@item()?['exposureLevel']"
+                                                    }
+                                                ],
+                                                "format": "CSV",
+                                                "from": "@body('Machines_-_Get_list_of_machines_-_Host_path')?['value']"
+                                            },
+                                            "runAfter": {
+                                                "Create_table_to_check_HostHighestRiskScore": [
+                                                    "Succeeded"
+                                                ]
+                                            },
+                                            "type": "Table"
+                                        },
+                                        "Create_table_to_check_HostHighestRiskScore": {
+                                            "inputs": {
+                                                "columns": [
+                                                    {
+                                                        "header": "",
+                                                        "value": "@item()['riskScore']"
+                                                    }
+                                                ],
+                                                "format": "CSV",
+                                                "from": "@body('Machines_-_Get_list_of_machines_-_Host_path')?['value']"
+                                            },
+                                            "runAfter": {
+                                                "Machines_-_Get_list_of_machines_-_Host_path": [
+                                                    "Succeeded"
+                                                ]
+                                            },
+                                            "type": "Table"
+                                        },
+                                        "Machines_-_Get_list_of_machines_-_Host_path": {
+                                            "inputs": {
+                                                "host": {
+                                                    "connection": {
+                                                        "name": "@parameters('$connections')['wdatp']['connectionId']"
+                                                    }
+                                                },
+                                                "method": "get",
+                                                "path": "/api/machines",
+                                                "queries": {
+                                                    "$filter": "id eq '@{coalesce(item()['RawEntity']?['additionalData']?['MdatpDeviceId'],'unknown')}' or computerDnsName eq '@{coalesce(concat(item()['RawEntity']?['hostName'],'.',item()['RawEntity']?['dnsDomain']),item()['FQDN'])}'",
+                                                    "$select": "id,computerDnsName,riskScore,exposureLevel"
+                                                }
+                                            },
+                                            "runAfter": {},
+                                            "type": "ApiConnection"
+                                        }
+                                    },
+                                    "foreach": "@body('Parse_JSON')?['Hosts']",
+                                    "runAfter": {},
+                                    "type": "Foreach"
+                                }
+                            },
+                            "runAfter": {
+                                "Condition_-_Terminate_if_no_supported_entities": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "type": "Scope"
+                        },
                         "Scope_IP": {
                             "actions": {
                                 "Create_table_to_check_IPsHighestExposureLevel": {
@@ -1101,9 +1279,102 @@
                                 ]
                             },
                             "type": "Scope"
+                        },
+                        "Terminate_Account_error": {
+                            "inputs": {
+                                "runError": {
+                                    "code": "@{result('For_each_account')[0]['outputs'][0]['outputs']['statusCode']}",
+                                    "message": "@{result('For_each_account')[0]['outputs'][0]['outputs']['body']}"
+                                },
+                                "runStatus": "Failed"
+                            },
+                            "runAfter": {
+                                "Response_error_Account": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "type": "Terminate"
+                        },
+                        "Terminate_Host_error": {
+                            "inputs": {
+                                "runError": {
+                                    "code": "@{result('For_each_host')[0]['outputs'][0]['outputs']['statusCode']}",
+                                    "message": "@{result('For_each_host')[0]['outputs'][0]['outputs']['body']}"
+                                },
+                                "runStatus": "Failed"
+                            },
+                            "runAfter": {
+                                "Response_error_Host": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "type": "Terminate"
+                        },
+                        "Terminate_IP_error": {
+                            "inputs": {
+                                "runError": {
+                                    "code": "@{result('For_each_IP_in_IPs')[0]['outputs'][0]['outputs']['statusCode']}",
+                                    "message": "@{result('For_each_IP_in_IPs')[0]['outputs'][0]['outputs']['body']}"
+                                },
+                                "runStatus": "Failed"
+                            },
+                            "runAfter": {
+                                "Response_error_IP": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "type": "Terminate"
                         }
                     },
-                    "outputs": {}
+                    "contentVersion": "1.0.0.0",
+                    "outputs": {},
+                    "parameters": {
+                        "$connections": {
+                            "defaultValue": {},
+                            "type": "Object"
+                        },
+                        "PlaybookInternalName": {
+                            "defaultValue": "MDEModule",
+                            "type": "String"
+                        },
+                        "PlaybookVersion": {
+                            "defaultValue": "0.0.5",
+                            "type": "String"
+                        },
+                        "ProjectName": {
+                            "defaultValue": "STAT",
+                            "type": "String"
+                        }
+                    },
+                    "triggers": {
+                        "triage": {
+                            "inputs": {
+                                "schema": {
+                                    "properties": {
+                                        "AddIncidentComments": {
+                                            "title": "Add comments to the incident",
+                                            "type": "boolean"
+                                        },
+                                        "Entities": {
+                                            "description": "Click here and select the EnrichedEntities object from the Dynamic content menu",
+                                            "title": "Enriched Entities",
+                                            "type": "array"
+                                        },
+                                        "LookbackInDays": {
+                                            "description": "Enter a value between 1 and 30",
+                                            "maximum": 30,
+                                            "minimum": 1,
+                                            "title": "Lookback period in days",
+                                            "type": "integer"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            },
+                            "kind": "Http",
+                            "type": "Request"
+                        }
+                    }
                 },
                 "parameters": {
                     "$connections": {


### PR DESCRIPTION
Added host entity support.
Logic is: we lookup the machine risk score and exposure level based on the Defender ID if provided in the raw entity, else based on the FQDN calculated from the raw entity.
Fixed some issue with the incident comment.
Added a terminate step after the response in case of API failure.

Fixes #110