### PR TITLE
Implement Module Version Check in Base Module

### DIFF
--- a/Modules/BaseModule/azuredeploy.json
+++ b/Modules/BaseModule/azuredeploy.json
@@ -48,7 +48,7 @@
                             "type": "Object"
                         },
                         "PlaybookVersion": {
-                            "defaultValue": "0.2.2",
+                            "defaultValue": "0.3.0",
                             "type": "String"
                         },
                         "PlaybookInternalName": {
@@ -97,6 +97,10 @@
                     "actions": {
                         "Compose": {
                             "runAfter": {
+                                "Convert_to_JSON": [
+                                    "Succeeded",
+                                    "Failed"
+                                ],
                                 "Filter_array_-_Other": [
                                     "Succeeded",
                                     "Failed"
@@ -146,6 +150,7 @@
                                 "IPs": "@variables('IPArray')",
                                 "IPsCount": "@length(variables('IPArray'))",
                                 "IncidentARMId": "@triggerBody()?['IncidentARMId']",
+                                "ModuleVersions": "@outputs('Convert_to_JSON')",
                                 "OtherEntities": "@body('Filter_array_-_Other')",
                                 "OtherEntitiesCount": "@length(body('Filter_array_-_Other'))",
                                 "URLs": "@variables('URLArray')",
@@ -165,7 +170,7 @@
                                     "inputs": {
                                         "body": {
                                             "incidentArmId": "@triggerBody()?['IncidentARMId']",
-                                            "message": "<p>@{body('Create_HTML_table_-_Accounts')}</p>"
+                                            "message": "<p>@{body('Create_HTML_table_-_Accounts')}@{if(not(equals(outputs('Compose')?['ModuleVersions'], null)), if(equals(parameters('PlaybookVersion'),outputs('Compose')?['ModuleVersions']?[parameters('PlaybookInternalName')]), '', concat('<br>Sentinel Triage AssistanT - Update Available: Installed Version: ', parameters('PlaybookVersion'), ', Available Version: ', outputs('Compose')?['ModuleVersions']?[parameters('PlaybookInternalName')])) , '')}</p>"
                                         },
                                         "host": {
                                             "connection": {
@@ -393,6 +398,16 @@
                                 ]
                             },
                             "type": "If"
+                        },
+                        "Convert_to_JSON": {
+                            "runAfter": {
+                                "HTTP_-_Version_Download": [
+                                    "Succeeded",
+                                    "Failed"
+                                ]
+                            },
+                            "type": "Compose",
+                            "inputs": "@json(body('HTTP_-_Version_Download'))"
                         },
                         "Filter_array_-_Accounts": {
                             "runAfter": {
@@ -925,6 +940,41 @@
                                 },
                                 "method": "GET",
                                 "uri": "https://graph.microsoft.com/v1.0/users?$top=1&$select=id"
+                            }
+                        },
+                        "HTTP_-_Version_Download": {
+                            "runAfter": {
+                                "HTTP_-_Version_Redirect": [
+                                    "Succeeded",
+                                    "Failed"
+                                ]
+                            },
+                            "type": "Http",
+                            "inputs": {
+                                "method": "GET",
+                                "retryPolicy": {
+                                    "count": 2,
+                                    "interval": "PT10S",
+                                    "type": "fixed"
+                                },
+                                "uri": "@{outputs('HTTP_-_Version_Redirect')['headers']?['Location']}"
+                            }
+                        },
+                        "HTTP_-_Version_Redirect": {
+                            "runAfter": {
+                                "HTTP_-_Test_API_Access": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "type": "Http",
+                            "inputs": {
+                                "method": "GET",
+                                "retryPolicy": {
+                                    "count": 2,
+                                    "interval": "PT10S",
+                                    "type": "fixed"
+                                },
+                                "uri": "https://aka.ms/mstatversion"
                             }
                         },
                         "Initialize_AccountsArray": {

--- a/Modules/BaseModule/readme.md
+++ b/Modules/BaseModule/readme.md
@@ -118,6 +118,19 @@ The base module must be called before any other modules in this solution.  It pe
   ],
   "IPsCount": 1,
   "IncidentARMId": "/subscriptions/397caaaa-d999-4abc-acdd-f3a40db41234/resourceGroups/sentinel-rg/providers/Microsoft.OperationalInsights/workspaces/sentinel-workspace/providers/Microsoft.SecurityInsights/Incidents/afdffc57-0ae5-4323-b75e-48a64fcb3280",
+  "ModuleVersions": {
+    "AADRisksModule": "0.0.4",
+    "BaseModule": "0.3.0",
+    "FileModule": "0.0.3",
+    "KQLModule": "0.0.5",
+    "MCASModule": "0.0.5",
+    "MDEModule": "0.1.1",
+    "OOFModule": "0.0.3",
+    "RelatedAlerts": "0.0.7",
+    "TIModule": "0.0.4",
+    "UEBAModule": "0.0.5",
+    "WatchlistModule": "0.0.5"
+  },
   "OtherEntities": [
     {
       "id": "/subscriptions/.../Entities/",

--- a/Modules/BaseModule/returnschema.json
+++ b/Modules/BaseModule/returnschema.json
@@ -334,6 +334,44 @@
             "description": "The ARM Id of the Azure Sentinel Incident",
             "type": "string"
         },
+        "ModuleVersions": {
+            "type": "object",
+            "properties": {
+                "AADRisksModule": {
+                    "type": "string"
+                },
+                "BaseModule": {
+                    "type": "string"
+                },
+                "FileModule": {
+                    "type": "string"
+                },
+                "KQLModule": {
+                    "type": "string"
+                },
+                "MCASModule": {
+                    "type": "string"
+                },
+                "MDEModule": {
+                    "type": "string"
+                },
+                "OOFModule": {
+                    "type": "string"
+                },
+                "RelatedAlerts": {
+                    "type": "string"
+                },
+                "TIModule": {
+                    "type": "string"
+                },
+                "UEBAModule": {
+                    "type": "string"
+                },
+                "WatchlistModule": {
+                    "type": "string"
+                }
+            }
+        },
         "URLs": {
             "type": "array",
             "description": "Array of URLs",

--- a/Modules/versions.json
+++ b/Modules/versions.json
@@ -1,6 +1,6 @@
 {
     "AADRisksModule": "0.0.4",
-    "BaseModule": "0.2.2",
+    "BaseModule": "0.3.0",
     "FileModule": "0.0.3",
     "KQLModule": "0.0.5",
     "MCASModule": "0.0.5",

--- a/Modules/versions.json
+++ b/Modules/versions.json
@@ -1,0 +1,13 @@
+{
+    "AADRisksModule": "0.0.4",
+    "BaseModule": "0.2.2",
+    "FileModule": "0.0.3",
+    "KQLModule": "0.0.5",
+    "MCASModule": "0.0.5",
+    "MDEModule": "0.1.1",
+    "OOFModule": "0.0.3",
+    "RelatedAlerts": "0.0.7",
+    "TIModule": "0.0.4",
+    "UEBAModule": "0.0.5",
+    "WatchlistModule": "0.0.5"
+}


### PR DESCRIPTION
This implements a version check in the base module and adds a comment as part of the user enrichment if the module is out of date.  The version check should not ever impact the ability for the module to complete and should simply return a null object in the output if it can't be completed for any reason.

This will provide easy insight into incidents if the base module is running on an older version.  The module version data is returned in the base module body so other modules can benefit from this data as well in subsequent updates.

Tests should really focus on if the version check can cause the module to fail.  I have tested this with a bad aka.ms url and a non-responsive url, both allow the module to return successfully.

Fixes #253 