### PR TITLE
related alerts tactics and severity update

### DIFF
--- a/Connector/azuredeploy.json
+++ b/Connector/azuredeploy.json
@@ -105,7 +105,7 @@
             "properties": {
                 "connectionParameters": {},
                 "capabilities": [],
-                "description": "The Microsoft Sentinel Triage assistance is an automation toolkit to simplify the construction of automation to analyze Sentinel Incidents (version 0.2.1)",
+                "description": "The Microsoft Sentinel Triage assistance is an automation toolkit to simplify the construction of automation to analyze Sentinel Incidents (version 0.2.2)",
                 "displayName": "[parameters('CustomConnectorDisplayName')]",
                 "iconUri": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACsAAAAtCAYAAAA3BJLdAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAMjSURBVFhH7Zk/TFNRFMa/tg8BkWr8E0uRyGAwOki0NVYTBhIlGISFGnVgrC5EGk1IGBwkMQw6NG7tggtxMDqoiYspEAZJoAZFISAJJFpsGLTUaqDQ1nfvuy20lL7b0vdqTX/JyT3f477ycbjv9N5WExVBgaBlY0FQNKsUCWvW7/djYmKCqdxiMplQWVnJVJYQszEGBweJcUVibGyM/ZbsKdxlMDQ0hMbGRpr79h+j404x/Jijo1hZmM1mmmfL/1HZby9eoaKigubZEgwGUdPeRvNcVHZbs4FAgI47Ra/X01EVs2+CWvjWaUoxCMDlPRGmJNLNiZm12WwwGo0058FisaC5uZkpCVmzt30CPqxoaE6oL4visWGTM5F0c2JmM6WrqwsOh4MpieLbrVKoYpYsKd5oaGhgd21F1ixZe8O1a/FIXq8Enjkr12z4U3smbYTfjbPZqcnLMtC1X0HpUxd23bvLrvCRF7PammrozpuhOXmcXeFDVbOkoiX2W9CeM1GtOVJFNQkeZM2Sht/v3wiik+GZQxCsbdQYqSqBVDjnZp/4dfHYzqzcHEJ0ehaRUQ8iX72SXg5IWgweZM3mklDvI6xctyH8/DXVkalZqknwoKrZnZIXs2sOJ+2rqzdusit8qLJFzOS1WlpaMDIyknIjI27mlIcY6OjogNvthtcrPVzJdHd3Y2BgAJOTk+zKVrgqG7r/UHySvzCVHtJLhavS6YDwtvoEHevq6rC4uEhPD6kgR/WZmRncWZrHp3Ao+y0ieWrDo+NcEfV+Z3dJXCgpp3Fw/itOrYbjOjlKP07Rn+s1OnbnVrgqu/7sJRYWfHD/3thgE4y7BWg3/bn1unUYLKfjTZ/Qe7iWZfI0NTXhwef3GJ6bTVlZ7gesnzb8xH+ExVDGMomLQgiXhFWmJDI5KTidTrhcLng8nuJJQVWKZpWiaFYpCsrstn22p6eHjjGmUY5Rf4gpiaNVBxD+tcwUcPbQXuz7ucSURF9fH8vkaW1tpT2WvC2n6rOqffKdaYhmmasNEipLvk+w2+1M5Rer1YrOzk6mJBLM/usUu4FSFJBZ4C9uB2sPxMPD5QAAAABJRU5ErkJggg==",
                 "swagger": {
@@ -113,7 +113,7 @@
                     "info": {
                         "version": "1.0.0",
                         "title": "STAT",
-                        "description": "The Microsoft Sentinel Triage assistance is an automation toolkit to simplify the construction of automation to analyze Sentinel Incidents (version 0.2.1)"
+                        "description": "The Microsoft Sentinel Triage assistance is an automation toolkit to simplify the construction of automation to analyze Sentinel Incidents (version 0.2.2)"
                     },
                     "host": "[string(split(split(listCallbackUrl(resourceId('Microsoft.Logic/workflows/triggers', parameters('STATCoordinatorPlaybookName'), 'manual'), '2017-07-01').value, ':443')[0], '//')[1])]",
                     "basePath": "/",
@@ -1128,6 +1128,10 @@
                                                                 "type": "string",
                                                                 "description": "ProviderName in DetailedResults array"
                                                             },
+                                                            "Tactics": {
+                                                                "type": "string",
+                                                                "description": "Tactics in DetailedResults array"
+                                                            },
                                                             "AccountEntityMatch": {
                                                                 "type": "boolean",
                                                                 "description": "AccountEntityMatch in DetailedResults array"
@@ -1143,6 +1147,10 @@
                                                         }
                                                     },
                                                     "description": "Array of DetailedResults"
+                                                },
+                                                "HighestSeverityAlert": {
+                                                    "type": "string",
+                                                    "description": "The severity of the highest severity alert found"
                                                 },
                                                 "RelatedAccountAlertsCount": {
                                                     "type": "integer",

--- a/Modules/RelatedAlerts/azuredeploy.json
+++ b/Modules/RelatedAlerts/azuredeploy.json
@@ -48,7 +48,7 @@
                             "type": "Object"
                         },
                         "PlaybookVersion": {
-                            "defaultValue": "0.0.7",
+                            "defaultValue": "0.1.0",
                             "type": "String"
                         },
                         "PlaybookInternalName": {
@@ -116,7 +116,7 @@
                                             "inputs": {
                                                 "body": {
                                                     "incidentArmId": "@body('Parse_JSON')?['IncidentARMId']",
-                                                    "message": "<p>There were @{length(body('HTTP')['tables'][0]['rows'])} related alerts found.<br>\n<br>\n@{body('Create_HTML_table')}<br>\n<br>\n</p>"
+                                                    "message": "<p>There were @{length(body('Select'))} related alerts found. @{if(greater(length(body('Select')), 6), 'A maximum of 6 results have been displayed', '')}<br>\n<br>\n@{body('Create_HTML_table')}<br>\n@{if(equals(body('Parse_JSON')?['ModuleVersions']?['RelatedAlerts'], null), '', if(not(equals(body('Parse_JSON')?['ModuleVersions']?['RelatedAlerts'], parameters('PlaybookVersion'))), concat('<br>Sentinel Triage AssistanT - RelatedAlerts Update Available: Installed Version: ', parameters('PlaybookVersion'), ', Available Version: ', body('Parse_JSON')?['ModuleVersions']?['RelatedAlerts']), ''))}</p>"
                                                 },
                                                 "host": {
                                                     "connection": {
@@ -132,7 +132,7 @@
                                             "type": "Table",
                                             "inputs": {
                                                 "format": "HTML",
-                                                "from": "@body('Select')"
+                                                "from": "@take(body('Select'), 6)"
                                             }
                                         }
                                     },
@@ -207,6 +207,7 @@
                                     "inputs": {
                                         "body": {
                                             "DetailedResults": "@body('Select')",
+                                            "HighestSeverityAlert": "@{body('Select')?[0]?['AlertSeverity']}",
                                             "RelatedAccountAlertsCount": "@length(body('Filter_array_-_Accounts'))",
                                             "RelatedAccountAlertsFound": "@if(greater(length(body('Filter_array_-_Accounts')), 0), true, false)",
                                             "RelatedAlertsCount": "@length(body('HTTP')['tables'][0]['rows'])",
@@ -252,6 +253,7 @@
                                         "inputs": {
                                             "body": {
                                                 "DetailedResults": [],
+                                                "HighestSeverityAlert": null,
                                                 "RelatedAccountAlertsCount": 0,
                                                 "RelatedAccountAlertsFound": false,
                                                 "RelatedAlertsCount": 0,
@@ -280,12 +282,15 @@
                         },
                         "Compose": {
                             "runAfter": {
-                                "Select_-_Account_Entities": [
+                                "HTTP_-_Get_Incident": [
+                                    "Succeeded"
+                                ],
+                                "Select_-_Alert_Info": [
                                     "Succeeded"
                                 ]
                             },
                             "type": "Compose",
-                            "inputs": "let incidentARMId = '@{body('Parse_JSON')?['IncidentARMId']}';\nlet accountData = @'@{replace(string(body('Select_-_Account_Entities')), '''', '\\''')}';\nlet ipData = @'@{replace(string(body('Parse_JSON')?['IPs']), '''', '\\''')}';\nlet hostData = @'@{replace(string(body('Parse_JSON')?['Hosts']), '''', '\\''')}';\nlet checkAccountEntity = @{triggerBody()?['CheckAccountEntityMatches']};\nlet checkIPEntity = @{triggerBody()?['CheckIPEntityMatches']};\nlet checkHostEntity = @{triggerBody()?['CheckHostEntityMatches']};\nlet lookback = @{triggerBody()?['LookbackInDays']}d;\nlet currentIncident = materialize (\nSecurityIncident\n| where TimeGenerated > ago(lookback)\n| where IncidentUrl endswith incidentARMId\n| summarize arg_max(TimeGenerated, *) by IncidentNumber);\nlet isFusionIncident = toscalar(currentIncident\n| project isFusion = iff(RelatedAnalyticRuleIds has \"BuiltInFusion\", true, false));\nlet accountEntities = toscalar(datatable(temp:string)['']\n| where checkAccountEntity\n| extend Entities = parse_json(accountData)\n| mv-expand todynamic(Entities)\n| project SamAccountName=Entities.onPremisesSamAccountName, SID=Entities.onPremisesSecurityIdentifier, UPNName=split(Entities.userPrincipalName,'@')[0], Friendly=Entities.friendlyName\n| extend EntityData = pack_array(SamAccountName, SID, UPNName, Friendly)\n| mv-apply EntityData on (where isnotempty(EntityData))\n| summarize EntityData=make_set(EntityData));\nlet ipEntities = toscalar(datatable(temp:string)['']\n| where checkIPEntity\n| extend Entities = parse_json(ipData)\n| mv-expand todynamic(Entities)\n| project IP= coalesce(Entities.Address, Entities.RawEntity.address, Entities.RawEntity.friendlyName)\n| where isnotempty( IP)\n| summarize EntityData=make_set(IP));\nlet hostEntities = toscalar(datatable(temp:string)['']\n| where checkHostEntity\n| extend Entities = parse_json(hostData)\n| mv-expand todynamic(Entities)\n| project FQDN=Entities.FQDN, Hostname=coalesce(Entities.Hostname, Entities.RawEntity.hostName, Entities.RawEntity.friendlyName)\n| extend EntityData = pack_array(FQDN, Hostname)\n| mv-apply EntityData on (where isnotempty(EntityData))\n| summarize EntityData=make_set(EntityData));\nlet currentIncidentAlerts = currentIncident\n| mv-expand AlertIds\n| project SystemAlertId=tostring(AlertIds);\nSecurityAlert \n| where TimeGenerated > ago(lookback) \n| summarize arg_max(TimeGenerated, *) by SystemAlertId \n| where SystemAlertId !in (currentIncidentAlerts) or isFusionIncident\n| mv-expand todynamic(Entities) \n| where Entities has_any (accountEntities) or ( Entities has_any (ipEntities) and Entities.Type == \"ip\") or Entities has_any (hostEntities) or (SystemAlertId in (currentIncidentAlerts) and isFusionIncident)\n| extend AccountEntityMatch = iff(Entities has_any (accountEntities), true, false), HostEntityMatch = iff(Entities has_any (hostEntities), true, false), IPEntityMatch = iff(Entities has_any (ipEntities) , true, false) \n| summarize AccountEntityMatch = max(AccountEntityMatch), IPEntityMatch=max(IPEntityMatch),HostEntityMatch=max(HostEntityMatch) by StartTime, DisplayName, AlertName, AlertSeverity, SystemAlertId, ProviderName"
+                            "inputs": "let incidentARMId = '@{body('Parse_JSON')?['IncidentARMId']}';\nlet alertData = @'@{body('Select_-_Alert_Info')}';\nlet relatedRules = @'@{body('HTTP_-_Get_Incident')?['properties']?['relatedAnalyticRuleIds']}';\nlet accountData = @'@{replace(string(body('Select_-_Account_Entities')), '''', '\\''')}';\nlet ipData = @'@{replace(string(body('Parse_JSON')?['IPs']), '''', '\\''')}';\nlet hostData = @'@{replace(string(body('Parse_JSON')?['Hosts']), '''', '\\''')}';\nlet checkAccountEntity = @{triggerBody()?['CheckAccountEntityMatches']};\nlet checkIPEntity = @{triggerBody()?['CheckIPEntityMatches']};\nlet checkHostEntity = @{triggerBody()?['CheckHostEntityMatches']};\nlet lookback = @{triggerBody()?['LookbackInDays']}d;\nlet severityOrder = datatable (AlertSeverity:string, Order:int)['Informational', 1, 'Low', 2, 'Medium', 3, 'High', 4];\nlet isFusionIncident = toscalar(datatable (temp:string)['']\n| extend analyticRules = relatedRules\n| extend fusion = iff(analyticRules has 'BuiltInFusion', true, false)\n| project fusion);\nlet accountEntities = toscalar(datatable(temp:string)['']\n| where checkAccountEntity\n| extend Entities = parse_json(accountData)\n| mv-expand todynamic(Entities)\n| project SamAccountName=Entities.onPremisesSamAccountName, SID=Entities.onPremisesSecurityIdentifier, UPNName=split(Entities.userPrincipalName,'@')[0], Friendly=Entities.friendlyName\n| extend EntityData = pack_array(SamAccountName, SID, UPNName, Friendly)\n| mv-apply EntityData on (where isnotempty(EntityData))\n| summarize EntityData=make_set(EntityData));\nlet ipEntities = toscalar(datatable(temp:string)['']\n| where checkIPEntity\n| extend Entities = parse_json(ipData)\n| mv-expand todynamic(Entities)\n| project IP= coalesce(Entities.Address, Entities.RawEntity.address, Entities.RawEntity.friendlyName)\n| where isnotempty( IP)\n| summarize EntityData=make_set(IP));\nlet hostEntities = toscalar(datatable(temp:string)['']\n| where checkHostEntity\n| extend Entities = parse_json(hostData)\n| mv-expand todynamic(Entities)\n| project FQDN=Entities.FQDN, Hostname=coalesce(Entities.Hostname, Entities.RawEntity.hostName, Entities.RawEntity.friendlyName)\n| extend EntityData = pack_array(FQDN, Hostname)\n| mv-apply EntityData on (where isnotempty(EntityData))\n| summarize EntityData=make_set(EntityData));\nlet currentIncidentAlerts = datatable (temp:string)['']\n| extend alertData = todynamic(alertData)\n| mv-expand alertData\n| project alertData.systemAlertId;\nSecurityAlert \n| where TimeGenerated > ago(lookback) \n| summarize arg_max(TimeGenerated, *) by SystemAlertId \n| where SystemAlertId !in (currentIncidentAlerts) or isFusionIncident\n| mv-expand todynamic(Entities) \n| where Entities has_any (accountEntities) or ( Entities has_any (ipEntities) and Entities.Type == \"ip\") or Entities has_any (hostEntities) or (SystemAlertId in (currentIncidentAlerts) and isFusionIncident)\n| extend AccountEntityMatch = iff(Entities has_any (accountEntities), true, false), HostEntityMatch = iff(Entities has_any (hostEntities), true, false), IPEntityMatch = iff(Entities has_any (ipEntities) , true, false) \n| summarize AccountEntityMatch = max(AccountEntityMatch), IPEntityMatch=max(IPEntityMatch),HostEntityMatch=max(HostEntityMatch) by StartTime, DisplayName, AlertSeverity, SystemAlertId, ProviderName, Tactics\n| join kind=leftouter severityOrder on AlertSeverity\n| sort by Order desc\n| project-away Order, AlertSeverity1"
                         },
                         "HTTP": {
                             "runAfter": {
@@ -305,6 +310,38 @@
                                 },
                                 "method": "POST",
                                 "uri": "https://api.loganalytics.io/v1/workspaces/@{body('Parse_JSON')?['WorkspaceId']}/query"
+                            }
+                        },
+                        "HTTP_-_Get_Alerts": {
+                            "runAfter": {
+                                "Select_-_Account_Entities": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "type": "Http",
+                            "inputs": {
+                                "authentication": {
+                                    "audience": "https://management.azure.com",
+                                    "type": "ManagedServiceIdentity"
+                                },
+                                "method": "POST",
+                                "uri": "https://management.azure.com@{body('Parse_JSON')?['IncidentARMId']}/alerts?api-version=2021-10-01"
+                            }
+                        },
+                        "HTTP_-_Get_Incident": {
+                            "runAfter": {
+                                "Select_-_Account_Entities": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "type": "Http",
+                            "inputs": {
+                                "authentication": {
+                                    "audience": "https://management.azure.com",
+                                    "type": "ManagedServiceIdentity"
+                                },
+                                "method": "GET",
+                                "uri": "https://management.azure.com@{body('Parse_JSON')?['IncidentARMId']}?api-version=2021-10-01"
                             }
                         },
                         "Parse_JSON": {
@@ -647,6 +684,44 @@
                                             "description": "The ARM Id of the Azure Sentinel Incident",
                                             "type": "string"
                                         },
+                                        "ModuleVersions": {
+                                            "properties": {
+                                                "AADRisksModule": {
+                                                    "type": "string"
+                                                },
+                                                "BaseModule": {
+                                                    "type": "string"
+                                                },
+                                                "FileModule": {
+                                                    "type": "string"
+                                                },
+                                                "KQLModule": {
+                                                    "type": "string"
+                                                },
+                                                "MCASModule": {
+                                                    "type": "string"
+                                                },
+                                                "MDEModule": {
+                                                    "type": "string"
+                                                },
+                                                "OOFModule": {
+                                                    "type": "string"
+                                                },
+                                                "RelatedAlerts": {
+                                                    "type": "string"
+                                                },
+                                                "TIModule": {
+                                                    "type": "string"
+                                                },
+                                                "UEBAModule": {
+                                                    "type": "string"
+                                                },
+                                                "WatchlistModule": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
                                         "URLs": {
                                             "description": "Array of URLs",
                                             "items": {
@@ -716,6 +791,21 @@
                                     "onPremisesSamAccountName": "@item()?['onPremisesSamAccountName']",
                                     "onPremisesSecurityIdentifier": "@item()?['onPremisesSecurityIdentifier']",
                                     "userPrincipalName": "@item()?['userPrincipalName']"
+                                }
+                            }
+                        },
+                        "Select_-_Alert_Info": {
+                            "runAfter": {
+                                "HTTP_-_Get_Alerts": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "type": "Select",
+                            "inputs": {
+                                "from": "@body('HTTP_-_Get_Alerts')?['value']",
+                                "select": {
+                                    "systemAlertId": "@item()?['properties']?['systemAlertId']",
+                                    "tactics": "@item()?['properties']?['tactics']"
                                 }
                             }
                         }

--- a/Modules/RelatedAlerts/readme.md
+++ b/Modules/RelatedAlerts/readme.md
@@ -24,6 +24,7 @@ This module will check the incidient entities to see if there are any other aler
 |Property|Description|
 |---|---|
 |DetailedResults|An array of each related alert that was found|
+|HighestSeverityAlert|The severity of the highest severity alert found (High, Medium, Low or Informational)|
 |RelatedAlertsCount|Number of related alerts found. This number may exceed the sum of other related alert counts as an alert may be related to more than one entity type.|
 |RelatedAlertsFound|true/false indicating if related alerts were found|
 |RelatedAccountAlertsCount|Number of alerts related to account entity found|
@@ -41,10 +42,10 @@ This module will check the incidient entities to see if there are any other aler
     {
       "StartTime": "2021-11-03T12:16:29.541Z",
       "DisplayName": "Alert1",
-      "AlertName": "Alert1",
       "AlertSeverity": "Informational",
       "SystemAlertId": "55d2036d-e471-4210-bfcd-fead43b85cf8",
       "ProviderName": "ASI Scheduled Alerts",
+      "Tactics": "InitialAccess",
       "AccountEntityMatch": true,
       "IPEntityMatch": true,
       "HostEntityMatch": true
@@ -52,15 +53,16 @@ This module will check the incidient entities to see if there are any other aler
     {
       "StartTime": "2021-11-01T20:23:45.386Z",
       "DisplayName": "Alert2",
-      "AlertName": "Alert2",
       "AlertSeverity": "Informational",
       "SystemAlertId": "5342baa5-531d-7496-6f5f-b3e9c4a077dd",
       "ProviderName": "ASI Scheduled Alerts",
+      "Tactics": "InitialAccess",
       "AccountEntityMatch": true,
       "IPEntityMatch": false,
       "HostEntityMatch": true
     }
   ],
+  "HighestSeverityAlert": "Informational",
   "RelatedAccountAlertsCount": 2,
   "RelatedAccountAlertsFound": true,
   "RelatedAlertsCount": 2,

--- a/Modules/RelatedAlerts/returnschema.json
+++ b/Modules/RelatedAlerts/returnschema.json
@@ -24,6 +24,9 @@
                     "ProviderName": {
                         "type": "string"
                     },
+                    "Tactics": {
+                        "type": "string"
+                    },
                     "AccountEntityMatch": {
                         "type": "boolean"
                     },
@@ -35,6 +38,9 @@
                     }
                 }
             }
+        },
+        "HighestSeverityAlert": {
+            "type": "string"
         },
         "RelatedAlertsCount": {
             "type": "integer"

--- a/Modules/versions.json
+++ b/Modules/versions.json
@@ -6,7 +6,7 @@
     "MCASModule": "0.0.5",
     "MDEModule": "0.1.1",
     "OOFModule": "0.0.3",
-    "RelatedAlerts": "0.0.7",
+    "RelatedAlerts": "0.1.0",
     "TIModule": "0.0.4",
     "UEBAModule": "0.0.5",
     "WatchlistModule": "0.0.5"


### PR DESCRIPTION
* Fixes #246 - fixes this by using the API instead of log analytics query to return linked alerts
* Fixes #244 - Adds highest severity alert information to return data
* Starts work on #249 by including MITRE Tactics in enrichments and return data
* Adds version checking into module

Not in this change: Alert linking as I am still hitting the 3000 character comment limit in the API

[Deploy this update](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fbriandelmsft%2FSentinelAutomationModules%2Falertsdeploy%2FDeploy%2Fazuredeploy.json/createUIDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2Fbriandelmsft%2FSentinelAutomationModules%2Falertsdeploy%2FDeploy%2FcreateUiDefinition.json)