### PR TITLE
Lookback optional in TI Module

### DIFF
--- a/Connector/azuredeploy.json
+++ b/Connector/azuredeploy.json
@@ -105,7 +105,7 @@
             "properties": {
                 "connectionParameters": {},
                 "capabilities": [],
-                "description": "The Microsoft Sentinel Triage assistance is an automation toolkit to simplify the construction of automation to analyze Sentinel Incidents (version 0.2.2)",
+                "description": "The Microsoft Sentinel Triage assistance is an automation toolkit to simplify the construction of automation to analyze Sentinel Incidents (version 0.2.3)",
                 "displayName": "[parameters('CustomConnectorDisplayName')]",
                 "iconUri": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACsAAAAtCAYAAAA3BJLdAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAMjSURBVFhH7Zk/TFNRFMa/tg8BkWr8E0uRyGAwOki0NVYTBhIlGISFGnVgrC5EGk1IGBwkMQw6NG7tggtxMDqoiYspEAZJoAZFISAJJFpsGLTUaqDQ1nfvuy20lL7b0vdqTX/JyT3f477ycbjv9N5WExVBgaBlY0FQNKsUCWvW7/djYmKCqdxiMplQWVnJVJYQszEGBweJcUVibGyM/ZbsKdxlMDQ0hMbGRpr79h+j404x/Jijo1hZmM1mmmfL/1HZby9eoaKigubZEgwGUdPeRvNcVHZbs4FAgI47Ra/X01EVs2+CWvjWaUoxCMDlPRGmJNLNiZm12WwwGo0058FisaC5uZkpCVmzt30CPqxoaE6oL4visWGTM5F0c2JmM6WrqwsOh4MpieLbrVKoYpYsKd5oaGhgd21F1ixZe8O1a/FIXq8Enjkr12z4U3smbYTfjbPZqcnLMtC1X0HpUxd23bvLrvCRF7PammrozpuhOXmcXeFDVbOkoiX2W9CeM1GtOVJFNQkeZM2Sht/v3wiik+GZQxCsbdQYqSqBVDjnZp/4dfHYzqzcHEJ0ehaRUQ8iX72SXg5IWgweZM3mklDvI6xctyH8/DXVkalZqknwoKrZnZIXs2sOJ+2rqzdusit8qLJFzOS1WlpaMDIyknIjI27mlIcY6OjogNvthtcrPVzJdHd3Y2BgAJOTk+zKVrgqG7r/UHySvzCVHtJLhavS6YDwtvoEHevq6rC4uEhPD6kgR/WZmRncWZrHp3Ao+y0ieWrDo+NcEfV+Z3dJXCgpp3Fw/itOrYbjOjlKP07Rn+s1OnbnVrgqu/7sJRYWfHD/3thgE4y7BWg3/bn1unUYLKfjTZ/Qe7iWZfI0NTXhwef3GJ6bTVlZ7gesnzb8xH+ExVDGMomLQgiXhFWmJDI5KTidTrhcLng8nuJJQVWKZpWiaFYpCsrstn22p6eHjjGmUY5Rf4gpiaNVBxD+tcwUcPbQXuz7ucSURF9fH8vkaW1tpT2WvC2n6rOqffKdaYhmmasNEipLvk+w2+1M5Rer1YrOzk6mJBLM/usUu4FSFJBZ4C9uB2sPxMPD5QAAAABJRU5ErkJggg==",
                 "swagger": {
@@ -113,7 +113,7 @@
                     "info": {
                         "version": "1.0.0",
                         "title": "STAT",
-                        "description": "The Microsoft Sentinel Triage assistance is an automation toolkit to simplify the construction of automation to analyze Sentinel Incidents (version 0.2.2)"
+                        "description": "The Microsoft Sentinel Triage assistance is an automation toolkit to simplify the construction of automation to analyze Sentinel Incidents (version 0.2.3)"
                     },
                     "host": "[string(split(split(listCallbackUrl(resourceId('Microsoft.Logic/workflows/triggers', parameters('STATCoordinatorPlaybookName'), 'manual'), '2017-07-01').value, ':443')[0], '//')[1])]",
                     "basePath": "/",
@@ -859,7 +859,8 @@
                                                     "type": "integer",
                                                     "format": "int32",
                                                     "description": "Number of days to lookback in Threat Intel for matches",
-                                                    "title": ""
+                                                    "title": "",
+                                                    "x-ms-visibility": "advanced"
                                                 }
                                             },
                                             "default": {
@@ -867,8 +868,7 @@
                                                 "Entities": ""
                                             },
                                             "required": [
-                                                "BaseModuleBody",
-                                                "LookbackInDays"
+                                                "BaseModuleBody"
                                             ]
                                         },
                                         "required": true

--- a/Modules/TIModule/azuredeploy.json
+++ b/Modules/TIModule/azuredeploy.json
@@ -133,7 +133,7 @@
                                     "inputs": {
                                         "body": {
                                             "incidentArmId": "@body('Parse_JSON')?['IncidentARMId']",
-                                            "message": "<p>A total of @{length(outputs('Compose_-_DetailedResults'))} matching TI indicators were found.<br>\n<br>\n@{body('Create_HTML_table')}</p>"
+                                            "message": "<p>A total of @{length(outputs('Compose_-_DetailedResults'))} matching TI indicators were found.<br>\n<br>\n@{body('Create_HTML_table')}<br>\n@{if(equals(body('Parse_JSON')?['ModuleVersions']?['TIModule'], null), '', if(not(equals(body('Parse_JSON')?['ModuleVersions']?['TIModule'], parameters('PlaybookVersion'))), concat('<br>Sentinel Triage AssistanT - Threat Intel Update Available: Installed Version: ', parameters('PlaybookVersion'), ', Available Version: ', body('Parse_JSON')?['ModuleVersions']?['TIModule']), ''))}</p>"
                                         },
                                         "host": {
                                             "connection": {
@@ -191,7 +191,7 @@
                                         },
                                         "body": {
                                             "query": "@{outputs('Compose_-_Domain')}",
-                                            "timespan": "P@{triggerBody()?['LookbackInDays']}D"
+                                            "timespan": "P@{variables('Lookback')}D"
                                         },
                                         "method": "POST",
                                         "uri": "https://api.loganalytics.io/v1/workspaces/@{body('Parse_JSON')?['WorkspaceId']}/query"
@@ -282,7 +282,7 @@
                                         },
                                         "body": {
                                             "query": "@{outputs('Compose_-_File_Hash')}",
-                                            "timespan": "P@{triggerBody()?['LookbackInDays']}D"
+                                            "timespan": "P@{variables('Lookback')}D"
                                         },
                                         "method": "POST",
                                         "uri": "https://api.loganalytics.io/v1/workspaces/@{body('Parse_JSON')?['WorkspaceId']}/query"
@@ -373,7 +373,7 @@
                                         },
                                         "body": {
                                             "query": "@{outputs('Compose_-_IP')}",
-                                            "timespan": "P@{triggerBody()?['LookbackInDays']}D"
+                                            "timespan": "P@{variables('Lookback')}D"
                                         },
                                         "method": "POST",
                                         "uri": "https://api.loganalytics.io/v1/workspaces/@{body('Parse_JSON')?['WorkspaceId']}/query"
@@ -464,7 +464,7 @@
                                         },
                                         "body": {
                                             "query": "@{outputs('Compose_-_URL')}",
-                                            "timespan": "P@{triggerBody()?['LookbackInDays']}D"
+                                            "timespan": "P@{variables('Lookback')}D"
                                         },
                                         "method": "POST",
                                         "uri": "https://api.loganalytics.io/v1/workspaces/@{body('Parse_JSON')?['WorkspaceId']}/query"
@@ -536,7 +536,7 @@
                         },
                         "Initialize_variable": {
                             "runAfter": {
-                                "Parse_JSON": [
+                                "Initialize_variable_-_Lookback": [
                                     "Succeeded"
                                 ]
                             },
@@ -547,6 +547,23 @@
                                         "name": "emptyArray",
                                         "type": "array",
                                         "value": []
+                                    }
+                                ]
+                            }
+                        },
+                        "Initialize_variable_-_Lookback": {
+                            "runAfter": {
+                                "Parse_JSON": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "type": "InitializeVariable",
+                            "inputs": {
+                                "variables": [
+                                    {
+                                        "name": "Lookback",
+                                        "type": "string",
+                                        "value": "@{coalesce(triggerBody()?['LookbackInDays'], '14')}"
                                     }
                                 ]
                             }
@@ -890,6 +907,44 @@
                                         "IncidentARMId": {
                                             "description": "The ARM Id of the Azure Sentinel Incident",
                                             "type": "string"
+                                        },
+                                        "ModuleVersions": {
+                                            "properties": {
+                                                "AADRisksModule": {
+                                                    "type": "string"
+                                                },
+                                                "BaseModule": {
+                                                    "type": "string"
+                                                },
+                                                "FileModule": {
+                                                    "type": "string"
+                                                },
+                                                "KQLModule": {
+                                                    "type": "string"
+                                                },
+                                                "MCASModule": {
+                                                    "type": "string"
+                                                },
+                                                "MDEModule": {
+                                                    "type": "string"
+                                                },
+                                                "OOFModule": {
+                                                    "type": "string"
+                                                },
+                                                "RelatedAlerts": {
+                                                    "type": "string"
+                                                },
+                                                "TIModule": {
+                                                    "type": "string"
+                                                },
+                                                "UEBAModule": {
+                                                    "type": "string"
+                                                },
+                                                "WatchlistModule": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "type": "object"
                                         },
                                         "URLs": {
                                             "description": "Array of URLs",

--- a/Modules/TIModule/azuredeploy.json
+++ b/Modules/TIModule/azuredeploy.json
@@ -48,7 +48,7 @@
                             "type": "Object"
                         },
                         "PlaybookVersion": {
-                            "defaultValue": "0.0.4",
+                            "defaultValue": "0.1.0",
                             "type": "String"
                         },
                         "PlaybookInternalName": {

--- a/Modules/TIModule/readme.md
+++ b/Modules/TIModule/readme.md
@@ -19,7 +19,7 @@ This module will check the incident entities to see if there is corresponding th
 |CheckFileHashes|True/False (Default:True)|Check File Hash Entities for Theat Intelligence Matches|
 |CheckIPs|True/False (Default:True)|Check IP Entities for Threat Intelligence Matches|
 |CheckURLs|True/False (Default:True)|Check URL Entities for Threat Intelligence Matches|
-|LookbackInDays|1-90|This defines how far back to look through the ThreatIntelligenceIndicators table in Sentinel|
+|LookbackInDays|(Default:14)|This defines how far back to look through the ThreatIntelligenceIndicators table in Sentinel.  All active threat intel is included when looking back the default 14 days.|
 
 ## Return Properties
 

--- a/Modules/versions.json
+++ b/Modules/versions.json
@@ -7,7 +7,7 @@
     "MDEModule": "0.1.1",
     "OOFModule": "0.0.3",
     "RelatedAlerts": "0.1.0",
-    "TIModule": "0.0.4",
+    "TIModule": "0.1.0",
     "UEBAModule": "0.0.5",
     "WatchlistModule": "0.0.5"
 }


### PR DESCRIPTION
* Fixes #260 
* Adds version checking to TI Module

Since active TI is re-written to Sentinel every 14 days, it's not really necessary to ask how far to look back.  Moving this to an optional parameter for the module.

[Deployment this Update](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fbriandelmsft%2FSentinelAutomationModules%2Ftideploy%2FDeploy%2Fazuredeploy.json/createUIDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2Fbriandelmsft%2FSentinelAutomationModules%2Ftideploy%2FDeploy%2FcreateUiDefinition.json)