### PR TITLE
Restricting Logic App Callers

### DIFF
--- a/Deploy/readme.md
+++ b/Deploy/readme.md
@@ -20,4 +20,20 @@ To upgrade the Microsoft Sentinel Triage AssistanT you can simply deploy the sol
 
 ## Post Deployment
 
+### Grant Permissions
+
 * Run [GrantPermissions.ps1](GrantPermissions.ps1) to grant the necessary API and RBAC permissions to the logic apps deployed by this template.
+
+### Restrict Calls to STAT Coordinator (optional)
+
+All STAT modules, except the STAT Coordinator, are restricted to only being called from a Logic Apps IP and with a valid Shared Access Signature.  However, by default the STAT coordinator is only protected by the Shared Access Signature.  This is due to the Logic Apps Custom connector using IP addresses outside of the standard Logic Apps IP ranges.
+
+To restrict the STAT coordinator to only accept calls from the Logic apps custom connector:
+1. Locate the appropriate IP ranges for your Azure datacenter region [here](https://www.microsoft.com/download/details.aspx?id=56519) under the section **AzureConnectors.&lt;AzureRegion&gt;**
+2. Navigate in the Azure Portal to the **STAT-Coordinator** logic app
+3. Locate **Settings -> Workflow settings**
+4. Change the drop down menu from **Any IP** to **Specific IP ranges**
+5. Add the IP ranges obtained in step 1
+6. **Save**
+
+> Note: To maintain these IP restrictions, these steps will need to be repated when updating the STAT solution.

--- a/Deploy/readme.md
+++ b/Deploy/readme.md
@@ -36,4 +36,4 @@ To restrict the STAT coordinator to only accept calls from the Logic apps custom
 5. Add the IP ranges obtained in step 1
 6. **Save**
 
-> Note: To maintain these IP restrictions, these steps will need to be repated when updating the STAT solution.
+> Note: To maintain these IP restrictions, these steps will need to be repeated when updating the STAT solution.

--- a/Docs/deployment.md
+++ b/Docs/deployment.md
@@ -19,9 +19,9 @@ STAT can be deployed/updated via single ARM deployment
 
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fbriandelmsft%2FSentinelAutomationModules%2Fmain%2FDeploy%2Fazuredeploy.json/createUIDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2Fbriandelmsft%2FSentinelAutomationModules%2Fmain%2FDeploy%2FcreateUiDefinition.json)
 
-## Granting Permissions
+## Post Deloyment
 
-After the STAT template is deployed it will need to be granted permissions to various APIs and Sentinel itself to operate.  All components of STAT run as System Assigned Managed Identities.
+After the STAT template is deployed it will need to be granted permissions to various APIs and Sentinel itself to operate.  All components of STAT run as System Assigned Managed Identities.  You may also wish to restrict calls to the STAT Coordinator logic app to specified Azure data center regions.
 
 ### Grant Permissions
 
@@ -49,6 +49,20 @@ STAT Uses the following permissions
 |investigation.read|Microsoft Defender for Cloud Apps API|Retrieve user investigation priorities|
 |AdvancedHunting.Read.All|Microsoft 365 Security API|Execute KQL queries against the Microsoft 365 Security service|
 |Microsoft Sentinel Responder|Azure RBAC Role|Gives permissions to update incidents and read data from Sentinel. This is typically used by STAT to add comments to incidents.|
+
+### Restrict Calls to STAT Coordinator (optional)
+
+All STAT modules, except the STAT Coordinator, are restricted to only being called from a Logic Apps IP and with a valid Shared Access Signature.  However, by default the STAT coordinator is only protected by the Shared Access Signature.  This is due to the Logic Apps Custom connector using IP addresses outside of the standard Logic Apps IP ranges.
+
+To restrict the STAT coordinator to only accept calls from the Logic apps custom connector:
+1. Locate the appropriate IP ranges for your Azure datacenter region [here](https://www.microsoft.com/download/details.aspx?id=56519) under the section **AzureConnectors.&lt;AzureRegion&gt;**
+2. Navigate in the Azure Portal to the **STAT-Coordinator** logic app
+3. Locate **Settings -> Workflow settings**
+4. Change the drop down menu from **Any IP** to **Specific IP ranges**
+5. Add the IP ranges obtained in step 1
+6. **Save**
+
+> Note: To maintain these IP restrictions, these steps will need to be repated when updating the STAT solution.
 
 
 ---

--- a/Docs/deployment.md
+++ b/Docs/deployment.md
@@ -62,7 +62,7 @@ To restrict the STAT coordinator to only accept calls from the Logic apps custom
 5. Add the IP ranges obtained in step 1
 6. **Save**
 
-> Note: To maintain these IP restrictions, these steps will need to be repated when updating the STAT solution.
+> Note: To maintain these IP restrictions, these steps will need to be repeated when updating the STAT solution.
 
 
 ---

--- a/Modules/AADRisksModule/azuredeploy.json
+++ b/Modules/AADRisksModule/azuredeploy.json
@@ -39,6 +39,17 @@
             },
             "properties": {
                 "state": "Enabled",
+                "accessControl": {
+                    "triggers": {
+                        "allowedCallerIpAddresses": []
+                    },
+                    "actions": {
+                        "allowedCallerIpAddresses": []
+                    },
+                    "contents": {
+                        "allowedCallerIpAddresses": []
+                    }
+                },
                 "definition": {
                     "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
                     "actions": {

--- a/Modules/BaseModule/azuredeploy.json
+++ b/Modules/BaseModule/azuredeploy.json
@@ -39,6 +39,17 @@
             },
             "properties": {
                 "state": "Enabled",
+                "accessControl": {
+                    "triggers": {
+                        "allowedCallerIpAddresses": []
+                    },
+                    "actions": {
+                        "allowedCallerIpAddresses": []
+                    },
+                    "contents": {
+                        "allowedCallerIpAddresses": []
+                    }
+                },
                 "definition": {
                     "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
                     "contentVersion": "1.0.0.0",

--- a/Modules/FileModule/azuredeploy.json
+++ b/Modules/FileModule/azuredeploy.json
@@ -39,6 +39,17 @@
             },
             "properties": {
                 "state": "Enabled",
+                "accessControl": {
+                    "triggers": {
+                        "allowedCallerIpAddresses": []
+                    },
+                    "actions": {
+                        "allowedCallerIpAddresses": []
+                    },
+                    "contents": {
+                        "allowedCallerIpAddresses": []
+                    }
+                },
                "definition": {
                     "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
                     "actions": {

--- a/Modules/KQLModule/azuredeploy.json
+++ b/Modules/KQLModule/azuredeploy.json
@@ -39,6 +39,17 @@
             },
             "properties": {
                 "state": "Enabled",
+                "accessControl": {
+                    "triggers": {
+                        "allowedCallerIpAddresses": []
+                    },
+                    "actions": {
+                        "allowedCallerIpAddresses": []
+                    },
+                    "contents": {
+                        "allowedCallerIpAddresses": []
+                    }
+                },
                 "definition": {
                     "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
                     "contentVersion": "1.0.0.0",

--- a/Modules/MCASModule/azuredeploy.json
+++ b/Modules/MCASModule/azuredeploy.json
@@ -39,6 +39,17 @@
             },
             "properties": {
                 "state": "Enabled",
+                "accessControl": {
+                    "triggers": {
+                        "allowedCallerIpAddresses": []
+                    },
+                    "actions": {
+                        "allowedCallerIpAddresses": []
+                    },
+                    "contents": {
+                        "allowedCallerIpAddresses": []
+                    }
+                },
                 "definition": {
                     "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
                     "actions": {

--- a/Modules/MDEModule/azuredeploy.json
+++ b/Modules/MDEModule/azuredeploy.json
@@ -56,6 +56,17 @@
             },
             "properties": {
                 "state": "Enabled",
+                "accessControl": {
+                    "triggers": {
+                        "allowedCallerIpAddresses": []
+                    },
+                    "actions": {
+                        "allowedCallerIpAddresses": []
+                    },
+                    "contents": {
+                        "allowedCallerIpAddresses": []
+                    }
+                },
                 "definition": {
                     "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
                     "actions": {

--- a/Modules/OOFModule/azuredeploy.json
+++ b/Modules/OOFModule/azuredeploy.json
@@ -55,6 +55,17 @@
             },
             "properties": {
                 "state": "Enabled",
+                "accessControl": {
+                    "triggers": {
+                        "allowedCallerIpAddresses": []
+                    },
+                    "actions": {
+                        "allowedCallerIpAddresses": []
+                    },
+                    "contents": {
+                        "allowedCallerIpAddresses": []
+                    }
+                },
                 "definition": {
                     "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
                     "contentVersion": "1.0.0.0",

--- a/Modules/RelatedAlerts/azuredeploy.json
+++ b/Modules/RelatedAlerts/azuredeploy.json
@@ -39,6 +39,17 @@
             },
             "properties": {
                 "state": "Enabled",
+                "accessControl": {
+                    "triggers": {
+                        "allowedCallerIpAddresses": []
+                    },
+                    "actions": {
+                        "allowedCallerIpAddresses": []
+                    },
+                    "contents": {
+                        "allowedCallerIpAddresses": []
+                    }
+                },
                 "definition": {
                     "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
                     "contentVersion": "1.0.0.0",

--- a/Modules/TIModule/azuredeploy.json
+++ b/Modules/TIModule/azuredeploy.json
@@ -39,6 +39,17 @@
             },
             "properties": {
                 "state": "Enabled",
+                "accessControl": {
+                    "triggers": {
+                        "allowedCallerIpAddresses": []
+                    },
+                    "actions": {
+                        "allowedCallerIpAddresses": []
+                    },
+                    "contents": {
+                        "allowedCallerIpAddresses": []
+                    }
+                },
                 "definition": {
                     "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
                     "contentVersion": "1.0.0.0",

--- a/Modules/UEBAModule/azuredeploy.json
+++ b/Modules/UEBAModule/azuredeploy.json
@@ -39,6 +39,17 @@
             },
             "properties": {
                 "state": "Enabled",
+                "accessControl": {
+                    "triggers": {
+                        "allowedCallerIpAddresses": []
+                    },
+                    "actions": {
+                        "allowedCallerIpAddresses": []
+                    },
+                    "contents": {
+                        "allowedCallerIpAddresses": []
+                    }
+                },
                 "definition": {
                     "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
                     "contentVersion": "1.0.0.0",

--- a/Modules/WatchlistModule/azuredeploy.json
+++ b/Modules/WatchlistModule/azuredeploy.json
@@ -39,6 +39,17 @@
             },
             "properties": {
                 "state": "Enabled",
+                "accessControl": {
+                    "triggers": {
+                        "allowedCallerIpAddresses": []
+                    },
+                    "actions": {
+                        "allowedCallerIpAddresses": []
+                    },
+                    "contents": {
+                        "allowedCallerIpAddresses": []
+                    }
+                },
                 "definition": {
                     "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
                     "contentVersion": "1.0.0.0",


### PR DESCRIPTION
* Fixes #265 
* Relates to #257 
* All STAT modules are now restricted to only being called from other logic apps.  This provides an additional layer of security if the shared access signature is known.  Access keys can also be freely rotated in any module (not including the STAT-Coordinator).  This key rotation is not automated but will not impact the use of STAT (again, except STAT-Coordinator).
* The STAT coordinator cannot use this restriction as it is being called by a connector, not a 'logic app'.  This update also includes documentation update to how to locate and apply connector IP ranges for your azure region to the STAT coordinator logic app

[Deploy Update](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fbriandelmsft%2FSentinelAutomationModules%2Frestrict%2FDeploy%2Fazuredeploy.json/createUIDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2Fbriandelmsft%2FSentinelAutomationModules%2Frestrict%2FDeploy%2FcreateUiDefinition.json)