### PR TITLE
Update restrictions to restrict trigger only

### DIFF
--- a/Modules/AADRisksModule/azuredeploy.json
+++ b/Modules/AADRisksModule/azuredeploy.json
@@ -42,12 +42,6 @@
                 "accessControl": {
                     "triggers": {
                         "allowedCallerIpAddresses": []
-                    },
-                    "actions": {
-                        "allowedCallerIpAddresses": []
-                    },
-                    "contents": {
-                        "allowedCallerIpAddresses": []
                     }
                 },
                 "definition": {

--- a/Modules/BaseModule/azuredeploy.json
+++ b/Modules/BaseModule/azuredeploy.json
@@ -42,12 +42,6 @@
                 "accessControl": {
                     "triggers": {
                         "allowedCallerIpAddresses": []
-                    },
-                    "actions": {
-                        "allowedCallerIpAddresses": []
-                    },
-                    "contents": {
-                        "allowedCallerIpAddresses": []
                     }
                 },
                 "definition": {

--- a/Modules/FileModule/azuredeploy.json
+++ b/Modules/FileModule/azuredeploy.json
@@ -42,12 +42,6 @@
                 "accessControl": {
                     "triggers": {
                         "allowedCallerIpAddresses": []
-                    },
-                    "actions": {
-                        "allowedCallerIpAddresses": []
-                    },
-                    "contents": {
-                        "allowedCallerIpAddresses": []
                     }
                 },
                "definition": {

--- a/Modules/KQLModule/azuredeploy.json
+++ b/Modules/KQLModule/azuredeploy.json
@@ -42,12 +42,6 @@
                 "accessControl": {
                     "triggers": {
                         "allowedCallerIpAddresses": []
-                    },
-                    "actions": {
-                        "allowedCallerIpAddresses": []
-                    },
-                    "contents": {
-                        "allowedCallerIpAddresses": []
                     }
                 },
                 "definition": {

--- a/Modules/MCASModule/azuredeploy.json
+++ b/Modules/MCASModule/azuredeploy.json
@@ -42,12 +42,6 @@
                 "accessControl": {
                     "triggers": {
                         "allowedCallerIpAddresses": []
-                    },
-                    "actions": {
-                        "allowedCallerIpAddresses": []
-                    },
-                    "contents": {
-                        "allowedCallerIpAddresses": []
                     }
                 },
                 "definition": {

--- a/Modules/MDEModule/azuredeploy.json
+++ b/Modules/MDEModule/azuredeploy.json
@@ -59,12 +59,6 @@
                 "accessControl": {
                     "triggers": {
                         "allowedCallerIpAddresses": []
-                    },
-                    "actions": {
-                        "allowedCallerIpAddresses": []
-                    },
-                    "contents": {
-                        "allowedCallerIpAddresses": []
                     }
                 },
                 "definition": {

--- a/Modules/OOFModule/azuredeploy.json
+++ b/Modules/OOFModule/azuredeploy.json
@@ -58,12 +58,6 @@
                 "accessControl": {
                     "triggers": {
                         "allowedCallerIpAddresses": []
-                    },
-                    "actions": {
-                        "allowedCallerIpAddresses": []
-                    },
-                    "contents": {
-                        "allowedCallerIpAddresses": []
                     }
                 },
                 "definition": {

--- a/Modules/RelatedAlerts/azuredeploy.json
+++ b/Modules/RelatedAlerts/azuredeploy.json
@@ -42,12 +42,6 @@
                 "accessControl": {
                     "triggers": {
                         "allowedCallerIpAddresses": []
-                    },
-                    "actions": {
-                        "allowedCallerIpAddresses": []
-                    },
-                    "contents": {
-                        "allowedCallerIpAddresses": []
                     }
                 },
                 "definition": {

--- a/Modules/TIModule/azuredeploy.json
+++ b/Modules/TIModule/azuredeploy.json
@@ -42,12 +42,6 @@
                 "accessControl": {
                     "triggers": {
                         "allowedCallerIpAddresses": []
-                    },
-                    "actions": {
-                        "allowedCallerIpAddresses": []
-                    },
-                    "contents": {
-                        "allowedCallerIpAddresses": []
                     }
                 },
                 "definition": {

--- a/Modules/UEBAModule/azuredeploy.json
+++ b/Modules/UEBAModule/azuredeploy.json
@@ -42,12 +42,6 @@
                 "accessControl": {
                     "triggers": {
                         "allowedCallerIpAddresses": []
-                    },
-                    "actions": {
-                        "allowedCallerIpAddresses": []
-                    },
-                    "contents": {
-                        "allowedCallerIpAddresses": []
                     }
                 },
                 "definition": {

--- a/Modules/WatchlistModule/azuredeploy.json
+++ b/Modules/WatchlistModule/azuredeploy.json
@@ -42,12 +42,6 @@
                 "accessControl": {
                     "triggers": {
                         "allowedCallerIpAddresses": []
-                    },
-                    "actions": {
-                        "allowedCallerIpAddresses": []
-                    },
-                    "contents": {
-                        "allowedCallerIpAddresses": []
                     }
                 },
                 "definition": {


### PR DESCRIPTION
* #267 introduces restrictions that went beyond restricting the calling IP address and also restricted viewing run history
* this reverts part of #267 to only restrict calling IP

[Deploy Link](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fbriandelmsft%2FSentinelAutomationModules%2Frestrict%2FDeploy%2Fazuredeploy.json/createUIDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2Fbriandelmsft%2FSentinelAutomationModules%2Frestrict%2FDeploy%2FcreateUiDefinition.json)