### PR TITLE
Run-Playbook Module Addition and Base Module Enhancements

### DIFF
--- a/Connector/azuredeploy.json
+++ b/Connector/azuredeploy.json
@@ -70,6 +70,13 @@
             "defaultValue": "/subscriptions/<subscriptionId>/resourceGroups/<resourceGroupName>/providers/Microsoft.Logic/workflows/<RelatedAlertsModuleName>",
             "type": "String"
         },
+        "RunPlaybook_resourceid": {
+            "metadata": {
+                "description": "Resource Id of the RunPlaybook Playbook"
+            },
+            "defaultValue": "/subscriptions/<subscriptionId>/resourceGroups/<resourceGroupName>/providers/Microsoft.Logic/workflows/<RunPlaybookModuleName>",
+            "type": "String"
+        },
         "ScoringModule_resourceid": {
             "metadata": {
                 "description": "Resource Id of the ScoringModule Playbook"
@@ -112,7 +119,7 @@
             "properties": {
                 "connectionParameters": {},
                 "capabilities": [],
-                "description": "The Microsoft Sentinel Triage assistance is an automation toolkit to simplify the construction of automation to analyze Sentinel Incidents (version 0.4.0)",
+                "description": "The Microsoft Sentinel Triage assistance is an automation toolkit to simplify the construction of automation to analyze Sentinel Incidents (version 0.5.0)",
                 "displayName": "[parameters('CustomConnectorDisplayName')]",
                 "iconUri": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACsAAAAtCAYAAAA3BJLdAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAMjSURBVFhH7Zk/TFNRFMa/tg8BkWr8E0uRyGAwOki0NVYTBhIlGISFGnVgrC5EGk1IGBwkMQw6NG7tggtxMDqoiYspEAZJoAZFISAJJFpsGLTUaqDQ1nfvuy20lL7b0vdqTX/JyT3f477ycbjv9N5WExVBgaBlY0FQNKsUCWvW7/djYmKCqdxiMplQWVnJVJYQszEGBweJcUVibGyM/ZbsKdxlMDQ0hMbGRpr79h+j404x/Jijo1hZmM1mmmfL/1HZby9eoaKigubZEgwGUdPeRvNcVHZbs4FAgI47Ra/X01EVs2+CWvjWaUoxCMDlPRGmJNLNiZm12WwwGo0058FisaC5uZkpCVmzt30CPqxoaE6oL4visWGTM5F0c2JmM6WrqwsOh4MpieLbrVKoYpYsKd5oaGhgd21F1ixZe8O1a/FIXq8Enjkr12z4U3smbYTfjbPZqcnLMtC1X0HpUxd23bvLrvCRF7PammrozpuhOXmcXeFDVbOkoiX2W9CeM1GtOVJFNQkeZM2Sht/v3wiik+GZQxCsbdQYqSqBVDjnZp/4dfHYzqzcHEJ0ehaRUQ8iX72SXg5IWgweZM3mklDvI6xctyH8/DXVkalZqknwoKrZnZIXs2sOJ+2rqzdusit8qLJFzOS1WlpaMDIyknIjI27mlIcY6OjogNvthtcrPVzJdHd3Y2BgAJOTk+zKVrgqG7r/UHySvzCVHtJLhavS6YDwtvoEHevq6rC4uEhPD6kgR/WZmRncWZrHp3Ao+y0ieWrDo+NcEfV+Z3dJXCgpp3Fw/itOrYbjOjlKP07Rn+s1OnbnVrgqu/7sJRYWfHD/3thgE4y7BWg3/bn1unUYLKfjTZ/Qe7iWZfI0NTXhwef3GJ6bTVlZ7gesnzb8xH+ExVDGMomLQgiXhFWmJDI5KTidTrhcLng8nuJJQVWKZpWiaFYpCsrstn22p6eHjjGmUY5Rf4gpiaNVBxD+tcwUcPbQXuz7ucSURF9fH8vkaW1tpT2WvC2n6rOqffKdaYhmmasNEipLvk+w2+1M5Rer1YrOzk6mJBLM/usUu4FSFJBZ4C9uB2sPxMPD5QAAAABJRU5ErkJggg==",
                 "swagger": {
@@ -120,7 +127,7 @@
                     "info": {
                         "version": "1.0.0",
                         "title": "STAT",
-                        "description": "The Microsoft Sentinel Triage assistance is an automation toolkit to simplify the construction of automation to analyze Sentinel Incidents (version 0.4.0)"
+                        "description": "The Microsoft Sentinel Triage assistance is an automation toolkit to simplify the construction of automation to analyze Sentinel Incidents (version 0.5.0)"
                     },
                     "host": "[string(split(split(listCallbackUrl(resourceId('Microsoft.Logic/workflows/triggers', parameters('STATCoordinatorPlaybookName'), 'manual'), '2017-07-01').value, ':443')[0], '//')[1])]",
                     "basePath": "/",
@@ -2464,6 +2471,105 @@
                                     }
                                 }
                             }
+                        },
+                        "[concat(string(split(split(listCallbackUrl(resourceId('Microsoft.Logic/workflows/triggers', parameters('STATCoordinatorPlaybookName'), 'manual'), '2017-07-01').value, ':443')[1],'?')[0]), '/func/runplaybook')]": {
+                            "post": {
+                                "summary": "Run Playbook Module",
+                                "description": "Sentinel Triage AssistanT Module for running Microsoft Sentinel Playbooks.",
+                                "operationId": "RunPlaybook",
+                                "parameters": [
+                                    {
+                                        "name": "api-version",
+                                        "default": "2016-10-01",
+                                        "in": "query",
+                                        "type": "string",
+                                        "required": true,
+                                        "x-ms-visibility": "internal"
+                                    },
+                                    {
+                                        "name": "sp",
+                                        "default": "/triggers/manual/run",
+                                        "in": "query",
+                                        "type": "string",
+                                        "required": true,
+                                        "x-ms-visibility": "internal"
+                                    },
+                                    {
+                                        "name": "sv",
+                                        "default": "1.0",
+                                        "in": "query",
+                                        "type": "string",
+                                        "required": true,
+                                        "x-ms-visibility": "internal"
+                                    },
+                                    {
+                                        "name": "sig",
+                                        "default": "[string(split(listCallbackUrl(resourceId('Microsoft.Logic/workflows/triggers', parameters('STATCoordinatorPlaybookName'), 'manual'), '2017-07-01').value, 'sig=')[1])]",
+                                        "in": "query",
+                                        "type": "string",
+                                        "required": true,
+                                        "x-ms-visibility": "internal"
+                                    },
+                                    {
+                                        "name": "body",
+                                        "in": "body",
+                                        "schema": {
+                                            "type": "object",
+                                            "properties": {
+                                                "AddIncidentComments": {
+                                                    "type": "boolean",
+                                                    "description": "Add Comments to Microsoft Sentinel Incident",
+                                                    "title": "",
+                                                    "enum": [
+                                                        true,
+                                                        false
+                                                    ],
+                                                    "x-ms-visibility": "advanced"
+                                                },
+                                                "BaseModuleBody": {
+                                                    "type": "string",
+                                                    "description": "Body from STAT Base Module",
+                                                    "title": "",
+                                                    "x-ms-visibility": "important"
+                                                },
+                                                "LogicAppResourceId": {
+                                                    "type": "string",
+                                                    "description": "Resource Id of the Playbook you want to run"
+                                                },
+                                                "TenantId": {
+                                                    "type": "string",
+                                                    "description": "Azure AD Tenant Id"
+                                                },
+                                                "PlaybookName": {
+                                                    "type": "string",
+                                                    "description": "This description will be added to the incident comment for additional context on which Playbook was executed",
+                                                    "x-ms-visibility": "important"
+                                                }
+                                            },
+                                            "default": {
+                                                "AddIncidentComments": true,
+                                                "Entities": ""
+                                            },
+                                            "required": [
+                                                "BaseModuleBody",
+                                                "LogicAppResourceId",
+                                                "TenantId",
+                                                "PlaybookName"
+                                            ]
+                                        },
+                                        "required": true
+                                    }
+                                ],
+                                "responses": {
+                                    "default": {
+                                        "description": "default",
+                                        "schema": {
+                                            "type": "object",
+                                            "properties": {}
+                                        }
+                                    }
+                                }
+                            }
                         }
                     },
                     "definitions": {},
@@ -2491,7 +2597,7 @@
                     "contentVersion": "1.0.0.0",
                     "parameters": {
                         "PlaybookVersion": {
-                            "defaultValue": "0.4.0",
+                            "defaultValue": "0.5.0",
                             "type": "String"
                         },
                         "PlaybookInternalName": {
@@ -2869,6 +2975,48 @@
                                             "inputs": {
                                                 "body": "@body('Get-RelatedAlerts')",
                                                 "statusCode": "@outputs('Get-RelatedAlerts')['statusCode']"
+                                            }
+                                        }
+                                    }
+                                },
+                                "Case_-_Run_Playbook": {
+                                    "case": "runplaybook",
+                                    "actions": {
+                                        "Response_-_Run-Playbook": {
+                                            "runAfter": {
+                                                "Run-Playbook": [
+                                                    "Succeeded",
+                                                    "TimedOut",
+                                                    "Failed"
+                                                ]
+                                            },
+                                            "type": "Response",
+                                            "kind": "Http",
+                                            "inputs": {
+                                                "body": "@body('Run-Playbook')",
+                                                "statusCode": "@outputs('Run-Playbook')['statusCode']"
+                                            }
+                                        },
+                                        "Run-Playbook": {
+                                            "runAfter": {},
+                                            "type": "Workflow",
+                                            "inputs": {
+                                                "body": {
+                                                    "AddIncidentComments": "@coalesce(triggerBody()?['AddIncidentComments'], true)",
+                                                    "Entities": "@triggerBody()?['BaseModuleBody']",
+                                                    "LogicAppResourceId": "@{triggerBody()?['LogicAppResourceId']}",
+                                                    "PlaybookName": "@{triggerBody()?['PlaybookName']}",
+                                                    "TenantId": "@{triggerBody()?['TenantId']}"
+                                                },
+                                                "host": {
+                                                    "triggerName": "triage",
+                                                    "workflow": {
+                                                        "id": "[parameters('RunPlaybook_resourceid')]"
+                                                    }
+                                                },
+                                                "retryPolicy": {
+                                                    "type": "none"
+                                                }
                                             }
                                         }
                                     }

--- a/Connector/azuredeploy.json
+++ b/Connector/azuredeploy.json
@@ -421,6 +421,22 @@
                                                                 "type": "boolean",
                                                                 "description": "accountEnabled in Accounts array"
                                                             },
+                                                            "isAADPrivileged": {
+                                                                "type": "boolean",
+                                                                "description": "isAADPrivileged in Accounts array"
+                                                            },
+                                                            "isMfaRegistered": {
+                                                                "type": "boolean",
+                                                                "description": "isMfaRegistered in Accounts array"
+                                                            },
+                                                            "isSSPREnabled": {
+                                                                "type": "boolean",
+                                                                "description": "isSSPREnabled in Accounts array"
+                                                            },
+                                                            "isSSPRRegistered": {
+                                                                "type": "boolean",
+                                                                "description": "isSSPRRegistered in Accounts array"
+                                                            },
                                                             "manager": {
                                                                 "type": "object",
                                                                 "properties": {

--- a/Deploy/GrantPermissions.ps1
+++ b/Deploy/GrantPermissions.ps1
@@ -70,6 +70,7 @@ Set-RBACPermissions -MSIName $WatchlistLogicAppName -Role "Microsoft Sentinel Re
 
 #Base module
 Set-APIPermissions -MSIName $BaseLogicAppName -AppId "00000003-0000-0000-c000-000000000000" -PermissionName "User.Read.All"
+Set-APIPermissions -MSIName $BaseLogicAppName -AppId "00000003-0000-0000-c000-000000000000" -PermissionName "Reports.Read.All"
 Set-APIPermissions -MSIName $BaseLogicAppName -AppId "00000003-0000-0000-c000-000000000000" -PermissionName "RoleManagement.Read.Directory"
 Set-RBACPermissions -MSIName $BaseLogicAppName -Role "Microsoft Sentinel Responder"
 

--- a/Deploy/GrantPermissions.ps1
+++ b/Deploy/GrantPermissions.ps1
@@ -14,6 +14,7 @@ $OOFLogicAppName="Get-OOFDetails"                #Name of the OOF Logic App
 $MDELogicAppName="Get-MDEInsights"               #Name of the MDE Logic App
 $MCASLogicAppName="Get-MCASInvestigationScore"   #Name of the MCAS Logic App
 $RelatedAlertsLogicAppName="Get-RelatedAlerts"   #Name of the Related Alerts Logic App
+$RunPlaybookLogicAppName="Run-Playbook"          #Name of the Run-Playbook Logic App
 $ScoringLogicAppName="Calculate-RiskScore"       #Name of the Risk Scoring Logic App
 $TILogicAppName="Get-ThreatIntel"                #Name of the TI Logic App
 $WatchlistLogicAppName="Get-WatchlistInsights"   #Name of the Watchlists Logic App
@@ -96,3 +97,6 @@ Set-RBACPermissions -MSIName $SampleLogicAppName -Role "Microsoft Sentinel Respo
 
 #Calculate-RiskScore
 Set-RBACPermissions -MSIName $ScoringLogicAppName -Role "Microsoft Sentinel Responder"
+
+#Run-Playbook
+Set-RBACPermissions -MSIName $RunPlaybookLogicAppName -Role "Microsoft Sentinel Responder"

--- a/Deploy/azuredeploy.json
+++ b/Deploy/azuredeploy.json
@@ -54,6 +54,10 @@
             "defaultValue": "Run-KQLQuery",
             "type": "String"
         },
+        "RunPlaybookPlaybookName": {
+            "defaultValue": "Run-Playbook",
+            "type": "String"
+        },
         "BasePlaybookName": {
             "defaultValue": "Base-Module",
             "type": "String"
@@ -92,6 +96,7 @@
         "AADTemplate": "https://raw.githubusercontent.com/briandelmsft/SentinelAutomationModules/main/Modules/AADRisksModule/azuredeploy.json",
         "WatchlistTemplate": "https://raw.githubusercontent.com/briandelmsft/SentinelAutomationModules/main/Modules/WatchlistModule/azuredeploy.json",
         "FileTemplate": "https://raw.githubusercontent.com/briandelmsft/SentinelAutomationModules/main/Modules/FileModule/azuredeploy.json",
+        "RunPlaybookTemplate": "https://raw.githubusercontent.com/briandelmsft/SentinelAutomationModules/main/Modules/RunPlaybook/azuredeploy.json",
         "KQLTemplate": "https://raw.githubusercontent.com/briandelmsft/SentinelAutomationModules/main/Modules/KQLModule/azuredeploy.json",
         "TITemplate": "https://raw.githubusercontent.com/briandelmsft/SentinelAutomationModules/main/Modules/TIModule/azuredeploy.json",
         "ScoringTemplate": "https://raw.githubusercontent.com/briandelmsft/SentinelAutomationModules/main/Modules/ScoringModule/azuredeploy.json",
@@ -148,6 +153,23 @@
                 "parameters": {
                     "PlaybookName": {
                         "value": "[parameters('ScoringPlaybookName')]"
+                    }
+                }
+            }
+        },
+        {
+            "apiVersion": "2019-10-01",
+            "name": "RunPlaybookTemplate",
+            "type": "Microsoft.Resources/deployments",
+            "properties": {
+                "mode": "incremental",
+                "templateLink": {
+                    "uri": "[variables('RunPlaybookTemplate')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "PlaybookName": {
+                        "value": "[parameters('RunPlaybookPlaybookName')]"
                     }
                 }
             }
@@ -349,6 +371,7 @@
                 "[resourceId('Microsoft.Resources/deployments', 'FileTemplate')]",
                 "[resourceId('Microsoft.Resources/deployments', 'KQLTemplate')]",
                 "[resourceId('Microsoft.Resources/deployments', 'ScoringTemplate')]",
+                "[resourceId('Microsoft.Resources/deployments', 'RunPlaybookTemplate')]",
                 "[resourceId('Microsoft.Resources/deployments', 'TITemplate')]"
             ],
             "properties": {
@@ -399,6 +422,9 @@
                     },
                     "ScoringModule_resourceid": {
                         "value": "[reference('ScoringTemplate').outputs.resourceID.value]"
+                    },
+                    "RunPlaybook_resourceid": {
+                        "value": "[reference('RunPlaybookTemplate').outputs.resourceID.value]"
                     },
                     "WatchlistModule_resourceid": {
                         "value": "[reference('WatchlistTemplate').outputs.resourceID.value]"

--- a/Deploy/createUiDefinition.json
+++ b/Deploy/createUiDefinition.json
@@ -229,6 +229,16 @@
                                 "visible": true
                             },
                             {
+                                "name": "RunPlaybookPlaybookName",
+                                "type": "Microsoft.Common.TextBox",
+                                "label": "Run-Playbook Playbook Name",
+                                "placeholder": "",
+                                "defaultValue": "Run-Playbook",
+                                "toolTip": "",
+                                "constraints": {},
+                                "visible": true
+                            },
+                            {
                                 "name": "ScoringPlaybookName",
                                 "type": "Microsoft.Common.TextBox",
                                 "label": "Scoring Playbook Name",
@@ -404,6 +414,7 @@
             "UEBAPlaybookName": "[coalesce(steps('automationModules').advancedSetup.UEBAPlaybookName,'Get-UEBAInsights')]",
             "FilePlaybookName": "[coalesce(steps('automationModules').advancedSetup.FilePlaybookName,'Get-FileInsights')]",
             "KQLPlaybookName": "[coalesce(steps('automationModules').advancedSetup.KQLPlaybookName,'Run-KQLQuery')]",
+            "RunPlaybookPlaybookName": "[coalesce(steps('automationModules').advancedSetup.RunPlaybookPlaybookName,'Run-Playbook')]",
             "BasePlaybookName": "[coalesce(steps('automationModules').advancedSetup.BasePlaybookName,'Base-Module')]",
             "AADRisksPlaybookName": "[coalesce(steps('automationModules').advancedSetup.AADRisksPlaybookName,'Get-AADUserRisksInfo')]",
             "ScoringPlaybookName": "[coalesce(steps('automationModules').advancedSetup.ScoringPlaybookName,'Calculate-RiskScore')]",

--- a/Deploy/readme.md
+++ b/Deploy/readme.md
@@ -14,6 +14,10 @@ In most cases it is only necessary to deploy STAT a single time, but in some cir
 
 To upgrade the Microsoft Sentinel Triage AssistanT you can simply deploy the solution again, using the same settings as your original deployment.  This will update all of the STAT components but will maintain any existing connections to other logic apps you have a built and you will not be required to reassign the permissions as they will also be maintained.  When upgrading an advanced mode deployment, it is important that you use the same module names as the original deployment, otherwise new logic apps will be created.
 
+### Base Module version 0.4.0 and above
+
+When upgrading the base module from versions below 0.4.0 to this version or above the additional Graph API permissions of Reports.Read.All is used by the base module (See GrantPermissions.ps1).  If this permissions is not added, the module will return *Unknown* for all values that use the permission.
+
 ## Quick Deployment
 
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fbriandelmsft%2FSentinelAutomationModules%2Fmain%2FDeploy%2Fazuredeploy.json/createUIDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2Fbriandelmsft%2FSentinelAutomationModules%2Fmain%2FDeploy%2FcreateUiDefinition.json)

--- a/Modules/BaseModule/GrantPermissions.ps1
+++ b/Modules/BaseModule/GrantPermissions.ps1
@@ -29,5 +29,6 @@ function Set-RBACPermissions ($MSIName, $Role) {
 
 #Base-Module
 Set-APIPermissions -MSIName $BaseLogicAppName -AppId "00000003-0000-0000-c000-000000000000" -PermissionName "User.Read.All"
+Set-APIPermissions -MSIName $BaseLogicAppName -AppId "00000003-0000-0000-c000-000000000000" -PermissionName "Reports.Read.All"
 Set-APIPermissions -MSIName $BaseLogicAppName -AppId "00000003-0000-0000-c000-000000000000" -PermissionName "RoleManagement.Read.Directory"
 Set-RBACPermissions -MSIName $BaseLogicAppName -Role "Microsoft Sentinel Responder"

--- a/Modules/BaseModule/azuredeploy.json
+++ b/Modules/BaseModule/azuredeploy.json
@@ -53,7 +53,7 @@
                             "type": "Object"
                         },
                         "PlaybookVersion": {
-                            "defaultValue": "0.3.1",
+                            "defaultValue": "0.4.0",
                             "type": "String"
                         },
                         "PlaybookInternalName": {
@@ -155,6 +155,7 @@
                                 "IPs": "@variables('IPArray')",
                                 "IPsCount": "@length(variables('IPArray'))",
                                 "IncidentARMId": "@triggerBody()?['IncidentARMId']",
+                                "ModuleName": "@{parameters('PlaybookInternalName')}",
                                 "ModuleVersions": "@outputs('Convert_to_JSON')",
                                 "OtherEntities": "@body('Filter_array_-_Other')",
                                 "OtherEntitiesCount": "@length(body('Filter_array_-_Other'))",
@@ -224,6 +225,18 @@
                                             {
                                                 "header": "ManagerUPN",
                                                 "value": "@item()?['manager']?['userPrincipalName']"
+                                            },
+                                            {
+                                                "header": "MfaRegistered",
+                                                "value": "@coalesce(item()?['isMfaRegistered'], 'Unknown')"
+                                            },
+                                            {
+                                                "header": "SSPREnabled",
+                                                "value": "@coalesce(item()?['isSSPREnabled'], 'Unknown')"
+                                            },
+                                            {
+                                                "header": "SSPRRegistered",
+                                                "value": "@coalesce(item()?['isSSPRRegistered'], 'Unknown')"
                                             }
                                         ],
                                         "format": "HTML",
@@ -624,14 +637,33 @@
                                         "value": "@outputs('Compose_User_Unenriched')"
                                     }
                                 },
-                                "Compose_User": {
+                                "Compose_UPN": {
                                     "runAfter": {
-                                        "Select_Roles": [
+                                        "Compose_UserId": [
                                             "Succeeded"
                                         ]
                                     },
                                     "type": "Compose",
-                                    "inputs": "@addProperty(addProperty(addProperty(coalesce(body('HTTP_-_Email')?['value']?[0],body('HTTP_-_UPN'),body('HTTP_-_AADId'),body('HTTP_-_ObjectSid')?['value']?[0],body('HTTP_-_SamAccountName')?['value']?[0],body('HTTP_-_DistinguishedName')?['value']?[0]), 'AssignedRoles', body('Select_Roles')), 'RawEntity', item()['RawEntity']), 'isAADPrivileged', if(greater(length(body('Select_Roles')), 0), true, false))"
+                                    "inputs": "@coalesce(body('HTTP_-_Email')?['value']?[0]?['userPrincipalName'],body('HTTP_-_UPN')?['userPrincipalName'],body('HTTP_-_AADId')?['userPrincipalName'],body('HTTP_-_ObjectSid')?['value']?[0]?['userPrincipalName'],body('HTTP_-_SamAccountName')?['value']?[0]?['userPrincipalName'],body('HTTP_-_DistinguishedName')?['value']?[0]?['userPrincipalName'])"
+                                },
+                                "Compose_User": {
+                                    "runAfter": {
+                                        "HTTP_-_Security_Info": [
+                                            "Succeeded",
+                                            "Failed"
+                                        ]
+                                    },
+                                    "type": "Compose",
+                                    "inputs": "@addProperty(addProperty(addProperty(addProperty(addProperty(addProperty(coalesce(body('HTTP_-_Email')?['value']?[0],body('HTTP_-_UPN'),body('HTTP_-_AADId'),body('HTTP_-_ObjectSid')?['value']?[0],body('HTTP_-_SamAccountName')?['value']?[0],body('HTTP_-_DistinguishedName')?['value']?[0]), 'AssignedRoles', body('Select_Roles')), 'RawEntity', item()['RawEntity']), 'isAADPrivileged', if(greater(length(body('Select_Roles')), 0), true, false)), 'isMfaRegistered', body('HTTP_-_Security_Info')?['value']?[0]?['isMfaRegistered']), 'isSSPREnabled', body('HTTP_-_Security_Info')?['value']?[0]?['isEnabled']), 'isSSPRRegistered', body('HTTP_-_Security_Info')?['value']?[0]?['isRegistered'])"
+                                },
+                                "Compose_UserId": {
+                                    "runAfter": {
+                                        "Switch": [
+                                            "Succeeded"
+                                        ]
+                                    },
+                                    "type": "Compose",
+                                    "inputs": "@coalesce(body('HTTP_-_Email')?['value']?[0]?['id'],body('HTTP_-_UPN')?['id'],body('HTTP_-_AADId')?['id'],body('HTTP_-_ObjectSid')?['value']?[0]?['id'],body('HTTP_-_SamAccountName')?['value']?[0]?['id'],body('HTTP_-_DistinguishedName')?['value']?[0]?['id'])"
                                 },
                                 "Compose_User_Unenriched": {
                                     "runAfter": {
@@ -647,7 +679,7 @@
                                 },
                                 "HTTP_-_Roles": {
                                     "runAfter": {
-                                        "Switch": [
+                                        "Compose_UPN": [
                                             "Succeeded"
                                         ]
                                     },
@@ -658,7 +690,26 @@
                                             "type": "ManagedServiceIdentity"
                                         },
                                         "method": "GET",
-                                        "uri": "https://graph.microsoft.com/v1.0/roleManagement/directory/roleAssignments?$filter=principalId%20eq%20'@{coalesce(body('HTTP_-_Email')?['value']?[0]?['id'],body('HTTP_-_UPN')?['id'],body('HTTP_-_AADId')?['id'],body('HTTP_-_ObjectSid')?['value']?[0]?['id'],body('HTTP_-_SamAccountName')?['value']?[0]?['id'],body('HTTP_-_DistinguishedName')?['value']?[0]?['id'])}'&$expand=roleDefinition"
+                                        "uri": "https://graph.microsoft.com/v1.0/roleManagement/directory/roleAssignments?$filter=principalId%20eq%20'@{outputs('Compose_UserId')}'&$expand=roleDefinition"
+                                    }
+                                },
+                                "HTTP_-_Security_Info": {
+                                    "runAfter": {
+                                        "Select_Roles": [
+                                            "Succeeded"
+                                        ]
+                                    },
+                                    "type": "Http",
+                                    "inputs": {
+                                        "authentication": {
+                                            "audience": "https://graph.microsoft.com",
+                                            "type": "ManagedServiceIdentity"
+                                        },
+                                        "headers": {
+                                            "Content-Type": "application/json"
+                                        },
+                                        "method": "GET",
+                                        "uri": "https://graph.microsoft.com/beta/reports/credentialUserRegistrationDetails?$filter=userPrincipalName%20eq%20'@{outputs('Compose_UPN')}'"
                                     }
                                 },
                                 "Select_Roles": {

--- a/Modules/BaseModule/readme.md
+++ b/Modules/BaseModule/readme.md
@@ -55,7 +55,10 @@ The base module must be called before any other modules in this solution.  It pe
         "aadUserId": "f4610870-413b-4716-845c-426820fc9e96",
         "friendlyName": "f4610870-413b-4716-845c-426820fc9e96"
       },
-      "isAADPrivileged": false
+      "isAADPrivileged": false,
+      "isMfaRegistered": true,
+      "isSSPREnabled": true,
+      "isSSPRRegistered": true
     }
   ],
   "AccountsCount": 1,
@@ -170,6 +173,12 @@ The base module must be called before any other modules in this solution.  It pe
 }
 ```
 
+## Release Notes
+
+### Version 0.4.0
+
+This version adds enrichments about MFA and SSPR status to account entities.  This enrichments requires the additional graph permission of Reports.Read.All.  If you are upgrading from a previous version, you will need to add this additional permissions using the GrantPermissions.ps1 PowerShell script.  If this permissions is not added, the module will return *Unknown* for the SSPR and MFA status of the account.
+
 ## Advanced Deployment
 
 Deployment of the Sentinel Triage AssistanT should typically be performed from the [deployment template](/Deploy/readme.md), however in some cases you may wish to deploy an individual module below.
@@ -178,5 +187,5 @@ Deployment of the Sentinel Triage AssistanT should typically be performed from t
 
 ## Post Deployment
 
-* Grant the Logic app managed identity access to the Microsoft Graph application permissions User.Read.All and RoleManagement.Read.Directory (GrantPermissions.ps1)
+* Grant the Logic app managed identity access to the Microsoft Graph application permissions User.Read.All, Reports.Read.All and RoleManagement.Read.Directory (GrantPermissions.ps1)
 * Grant the Logic app Microsoft Sentinel Responder RBAC role on the resource group containing Microsoft Sentinel (GrantPermissions.ps1)

--- a/Modules/BaseModule/returnschema.json
+++ b/Modules/BaseModule/returnschema.json
@@ -52,6 +52,18 @@
                     "officeLocation": {
                         "description": "Array property in Accounts array"
                     },
+                    "isAADPrivileged": {
+                        "description": "Array property in Accounts array"
+                    },
+                    "isMfaRegistered": {
+                        "description": "Array property in Accounts array"
+                    },
+                    "isSSPREnabled": {
+                        "description": "Array property in Accounts array"
+                    },
+                    "isSSPRRegistered": {
+                        "description": "Array property in Accounts array"
+                    },
                     "manager": {
                         "type": "object",
                         "description": "Array property in Accounts array",

--- a/Modules/RunPlaybook/GrantPermissions.ps1
+++ b/Modules/RunPlaybook/GrantPermissions.ps1
@@ -1,0 +1,32 @@
+#  Install-Module AzureAD -Force # Install the module (You need admin on the machine)
+#  Install-Module -Name Az -Repository PSGallery -Force  # Install the module (You need admin on the machine)
+
+$TenantID=""  #Add your AAD Tenant Id
+$AzureSubscriptionId = "" #Azure Subscrition Id of Sentinel Subscription
+$SentinelResourceGroupName = "" #Resource Group Name of Sentinel
+
+$OOFLogicAppName="Run-Playbook"                #Name of the Run-Playbook Logic App
+
+Connect-AzureAD -TenantId $TenantID
+Login-AzAccount
+Set-AzContext -Subscription $AzureSubscriptionId
+
+function Set-APIPermissions ($MSIName, $AppId, $PermissionName) {
+    $MSI = Get-AppIds -AppName $MSIName
+    Start-Sleep -Seconds 2
+    $GraphServicePrincipal = Get-AzureADServicePrincipal -Filter "appId eq '$AppId'"
+    $AppRole = $GraphServicePrincipal.AppRoles | Where-Object {$_.Value -eq $PermissionName -and $_.AllowedMemberTypes -contains "Application"}
+    New-AzureAdServiceAppRoleAssignment -ObjectId $MSI.ObjectId -PrincipalId $MSI.ObjectId -ResourceId $GraphServicePrincipal.ObjectId -Id $AppRole.Id
+}
+
+function Get-AppIds ($AppName) {
+    Get-AzureADServicePrincipal -Filter "displayName eq '$AppName'"
+}
+
+function Set-RBACPermissions ($MSIName, $Role) {
+    $MSI = Get-AppIds -AppName $MSIName
+    New-AzRoleAssignment -ApplicationId $MSI.AppId -Scope "/subscriptions/$($AzureSubscriptionId)/resourceGroups/$($SentinelResourceGroupName)" -RoleDefinitionName $Role
+}
+
+#Run-Playbook
+Set-RBACPermissions -MSIName $OOFLogicAppName -Role "Microsoft Sentinel Responder"

--- a/Modules/RunPlaybook/azuredeploy.json
+++ b/Modules/RunPlaybook/azuredeploy.json
@@ -1,0 +1,655 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "PlaybookName": {
+            "defaultValue": "Run-Playbook",
+            "type": "String"
+        }
+    },
+    "variables": {
+        "AzureSentinelConnectionName": "[concat('azuresentinel-', parameters('PlaybookName'))]",
+        "ConversionServiceConnectionName": "[concat('conversionservice-', parameters('PlaybookName'))]"
+    },
+    "resources": [
+        {
+            "type": "Microsoft.Web/connections",
+            "apiVersion": "2016-06-01",
+            "name": "[variables('AzureSentinelConnectionName')]",
+            "location": "[resourceGroup().location]",
+            "kind": "V1",
+            "properties": {
+                "displayName": "[variables('AzureSentinelConnectionName')]",
+                "customParameterValues": {},
+                "parameterValueType": "Alternative",
+                "api": {
+                    "id": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', resourceGroup().location, '/managedApis/azuresentinel')]"
+                }
+            }
+        },
+        {
+            "type": "Microsoft.Logic/workflows",
+            "apiVersion": "2017-07-01",
+            "name": "[parameters('PlaybookName')]",
+            "location": "[resourceGroup().location]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/connections', variables('AzureSentinelConnectionName'))]",
+                "[resourceId('Microsoft.Web/connections', variables('ConversionServiceConnectionName'))]"
+            ],
+            "identity": {
+                "type": "SystemAssigned"
+            },
+            "properties": {
+                "state": "Enabled",
+                "accessControl": {
+                    "triggers": {
+                        "allowedCallerIpAddresses": []
+                    }
+                },
+                "definition": {
+                    "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
+                    "contentVersion": "1.0.0.0",
+                    "parameters": {
+                        "$connections": {
+                            "defaultValue": {},
+                            "type": "Object"
+                        },
+                        "PlaybookVersion": {
+                            "defaultValue": "0.0.1",
+                            "type": "String"
+                        },
+                        "PlaybookInternalName": {
+                            "defaultValue": "RunPlaybook",
+                            "type": "String"
+                        },
+                        "ProjectName": {
+                            "defaultValue": "STAT",
+                            "type": "String"
+                        }
+                    },
+                    "triggers": {
+                        "triage": {
+                            "type": "Request",
+                            "kind": "Http",
+                            "inputs": {
+                                "schema": {
+                                    "properties": {
+                                        "AddIncidentComments": {
+                                            "title": "Add comments to the incident",
+                                            "type": "boolean"
+                                        },
+                                        "Entities": {
+                                            "description": "Click here and select the Body object from the Base-Module output in the Dynamic content menu",
+                                            "title": "Base Module Body",
+                                            "type": "array"
+                                        },
+                                        "LogicAppResourceId": {
+                                            "title": "resourceId of the Logic App to execute",
+                                            "type": "string"
+                                        },
+                                        "PlaybookName": {
+                                            "title": "Friendly name for the Playbook to run",
+                                            "type": "string"
+                                        },
+                                        "TenantId": {
+                                            "title": "Azure AD Tenant Id",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "actions": {
+                        "Condition_-_Comment": {
+                            "actions": {
+                                "Add_comment_to_incident_(V3)": {
+                                    "runAfter": {},
+                                    "type": "ApiConnection",
+                                    "inputs": {
+                                        "body": {
+                                            "incidentArmId": "@body('Parse_JSON')?['IncidentARMId']",
+                                            "message": "<p>@{variables('incidentComment')}<br>\n</p>"
+                                        },
+                                        "host": {
+                                            "connection": {
+                                                "name": "@parameters('$connections')['azuresentinel']['connectionId']"
+                                            }
+                                        },
+                                        "method": "post",
+                                        "path": "/Incidents/Comment"
+                                    }
+                                }
+                            },
+                            "runAfter": {
+                                "Set_Success_Comment": [
+                                    "Succeeded",
+                                    "Skipped"
+                                ],
+                                "Set_variable_-_responseCode": [
+                                    "Succeeded",
+                                    "Skipped"
+                                ]
+                            },
+                            "expression": {
+                                "and": [
+                                    {
+                                        "equals": [
+                                            "@triggerBody()?['AddIncidentComments']",
+                                            true
+                                        ]
+                                    }
+                                ]
+                            },
+                            "type": "If"
+                        },
+                        "HTTP_-_Run_Playbook": {
+                            "runAfter": {
+                                "Initialize_variable_-_responseCode": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "type": "Http",
+                            "inputs": {
+                                "authentication": {
+                                    "audience": "https://management.azure.com",
+                                    "type": "ManagedServiceIdentity"
+                                },
+                                "body": {
+                                    "logicAppsResourceId": "@{triggerBody()?['LogicAppResourceId']}",
+                                    "tenantId": "@{triggerBody()?['TenantId']}"
+                                },
+                                "method": "POST",
+                                "queries": {
+                                    "api-version": "2022-07-01-preview"
+                                },
+                                "uri": "https://management.azure.com@{body('Parse_JSON')?['IncidentARMId']}/runPlaybook"
+                            }
+                        },
+                        "Initialize_variable_-_incidentComment": {
+                            "runAfter": {
+                                "Parse_JSON": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "type": "InitializeVariable",
+                            "inputs": {
+                                "variables": [
+                                    {
+                                        "name": "incidentComment",
+                                        "type": "string"
+                                    }
+                                ]
+                            }
+                        },
+                        "Initialize_variable_-_responseCode": {
+                            "runAfter": {
+                                "Initialize_variable_-_incidentComment": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "type": "InitializeVariable",
+                            "inputs": {
+                                "variables": [
+                                    {
+                                        "name": "responseCode",
+                                        "type": "integer",
+                                        "value": 200
+                                    }
+                                ]
+                            }
+                        },
+                        "Parse_JSON": {
+                            "runAfter": {},
+                            "type": "ParseJson",
+                            "inputs": {
+                                "content": "@triggerBody()?['Entities']",
+                                "schema": {
+                                    "properties": {
+                                        "Accounts": {
+                                            "description": "Array of User Accounts",
+                                            "items": {
+                                                "properties": {
+                                                    "AssignedRoles": {
+                                                        "description": "Array of assigned roles in Accounts array",
+                                                        "items": {
+                                                            "properties": {
+                                                                "Role": {
+                                                                    "description": "Array property in AssignedRoles array"
+                                                                }
+                                                            },
+                                                            "required": [],
+                                                            "type": "object"
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    "RawEntity": {
+                                                        "description": "Object containing Raw unenriched entity data in Accounts array",
+                                                        "properties": {
+                                                            "accountName": {
+                                                                "description": "accountName from RawEntity object in Accounts array"
+                                                            },
+                                                            "displayName": {
+                                                                "description": "dislayName from RawEntity object in Accounts array"
+                                                            },
+                                                            "friendlyName": {
+                                                                "description": "friendlyName from RawEntity object in Accounts array"
+                                                            },
+                                                            "isDomainJoined": {
+                                                                "description": "isDomainJoined from RawEntity object in Accounts array"
+                                                            },
+                                                            "sid": {
+                                                                "description": "sid from RawEntity object in Accounts array"
+                                                            },
+                                                            "upnSuffix": {
+                                                                "description": "upnSuffix from RawEntity object in Accounts array"
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    },
+                                                    "accountEnabled": {
+                                                        "description": "Array property in Accounts array"
+                                                    },
+                                                    "city": {
+                                                        "description": "Array property in Accounts array"
+                                                    },
+                                                    "country": {
+                                                        "description": "Array property in Accounts array"
+                                                    },
+                                                    "department": {
+                                                        "description": "Array property in Accounts array"
+                                                    },
+                                                    "id": {
+                                                        "description": "Array property in Accounts array"
+                                                    },
+                                                    "jobTitle": {
+                                                        "description": "Array property in Accounts array"
+                                                    },
+                                                    "mail": {
+                                                        "description": "Array property in Accounts array"
+                                                    },
+                                                    "manager": {
+                                                        "description": "Array property in Accounts array",
+                                                        "properties": {
+                                                            "@@odata.type": {
+                                                                "description": "Array property in Accounts array manager object"
+                                                            },
+                                                            "id": {
+                                                                "description": "Array property in Accounts array manager object"
+                                                            },
+                                                            "mail": {
+                                                                "description": "Array property in Accounts array manager object"
+                                                            },
+                                                            "userPrincipalName": {
+                                                                "description": "Array property in Accounts array manager object"
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    },
+                                                    "officeLocation": {
+                                                        "description": "Array property in Accounts array"
+                                                    },
+                                                    "onPremisesDistinguishedName": {
+                                                        "description": "Array property in Accounts array"
+                                                    },
+                                                    "onPremisesDomainName": {
+                                                        "description": "Array property in Accounts array"
+                                                    },
+                                                    "onPremisesSamAccountName": {
+                                                        "description": "Array property in Accounts array"
+                                                    },
+                                                    "onPremisesSecurityIdentifier": {
+                                                        "description": "Array property in Accounts array"
+                                                    },
+                                                    "onPremisesSyncEnabled": {
+                                                        "description": "Array property in Accounts array"
+                                                    },
+                                                    "state": {
+                                                        "description": "Array property in Accounts array"
+                                                    },
+                                                    "userPrincipalName": {
+                                                        "description": "Array property in Accounts array"
+                                                    }
+                                                },
+                                                "required": [],
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        "AccountsCount": {
+                                            "description": "Count of accounts processed by module",
+                                            "type": "integer"
+                                        },
+                                        "Domains": {
+                                            "description": "Array of Domains",
+                                            "items": {
+                                                "properties": {
+                                                    "RawEntity": {
+                                                        "description": "Object containing Raw unenriched entity data in Domains array",
+                                                        "properties": {
+                                                            "domainName": {
+                                                                "description": "domainName from RawEntity object in Domains array"
+                                                            },
+                                                            "friendlyName": {
+                                                                "description": "friendlyName from RawEntity object in Domains array"
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    }
+                                                },
+                                                "required": [],
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        "DomainsCount": {
+                                            "description": "Count of Domains processed by module",
+                                            "type": "integer"
+                                        },
+                                        "EntitiesCount": {
+                                            "description": "Count of all entities processed by enrichment module",
+                                            "type": "integer"
+                                        },
+                                        "FileHashes": {
+                                            "description": "Array of FileHashes",
+                                            "items": {
+                                                "properties": {
+                                                    "RawEntity": {
+                                                        "description": "Object containing Raw unenriched entity data in FileHashes array",
+                                                        "properties": {
+                                                            "algorithm": {
+                                                                "description": "algorithm from RawEntity object in FileHashes array"
+                                                            },
+                                                            "friendlyName": {
+                                                                "description": "friendlyName from RawEntity object in FileHashes array"
+                                                            },
+                                                            "hashValue": {
+                                                                "description": "hashValue from RawEntity object in FileHashes array"
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    }
+                                                },
+                                                "required": [],
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        "FileHashesCount": {
+                                            "description": "Count of File Hashes processed by module",
+                                            "type": "integer"
+                                        },
+                                        "Files": {
+                                            "description": "Array of Files",
+                                            "items": {
+                                                "properties": {
+                                                    "RawEntity": {
+                                                        "description": "Object containing Raw unenriched entity data in Files array",
+                                                        "properties": {
+                                                            "directory": {
+                                                                "description": "directory from RawEntity object in Files array"
+                                                            },
+                                                            "fileName": {
+                                                                "description": "fileName from RawEntity object in Files array"
+                                                            },
+                                                            "friendlyName": {
+                                                                "description": "friendlyName from RawEntity object in Files array"
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    }
+                                                },
+                                                "required": [],
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        "FilesCount": {
+                                            "description": "Count of Files processed by module",
+                                            "type": "integer"
+                                        },
+                                        "Hosts": {
+                                            "description": "Array of Hosts",
+                                            "items": {
+                                                "properties": {
+                                                    "DnsDomain": {
+                                                        "description": "Array property in Hosts array"
+                                                    },
+                                                    "FQDN": {
+                                                        "description": "Array property in Hosts array"
+                                                    },
+                                                    "Hostname": {
+                                                        "description": "Array property in Hosts array"
+                                                    },
+                                                    "RawEntity": {
+                                                        "description": "Object containing Raw unenriched entity data in Hosts array",
+                                                        "properties": {
+                                                            "dnsDomain": {
+                                                                "description": "dnsDomain from RawEntity object in Hosts array"
+                                                            },
+                                                            "friendlyName": {
+                                                                "description": "friendlyName from RawEntity object in Hosts array"
+                                                            },
+                                                            "hostName": {
+                                                                "description": "hostName from RawEntity object in Hosts array"
+                                                            },
+                                                            "netBiosName": {
+                                                                "description": "netBiosName from RawEntity object in Hosts array"
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    }
+                                                },
+                                                "required": [],
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        "HostsCount": {
+                                            "description": "Count of Hosts processed by module",
+                                            "type": "integer"
+                                        },
+                                        "IPs": {
+                                            "description": "Array of IP Addresses",
+                                            "items": {
+                                                "properties": {
+                                                    "Address": {
+                                                        "description": "Array property in IPs array"
+                                                    },
+                                                    "GeoData": {
+                                                        "description": "Array object in IPs array",
+                                                        "properties": {
+                                                            "asn": {
+                                                                "description": "Array property in IPs array GeoData object"
+                                                            },
+                                                            "carrier": {
+                                                                "description": "Array property in IPs array GeoData object"
+                                                            },
+                                                            "city": {
+                                                                "description": "Array property in IPs array GeoData object"
+                                                            },
+                                                            "cityCf": {
+                                                                "description": "Array property in IPs array GeoData object"
+                                                            },
+                                                            "continent": {
+                                                                "description": "Array property in IPs array GeoData object"
+                                                            },
+                                                            "country": {
+                                                                "description": "Array property in IPs array GeoData object"
+                                                            },
+                                                            "countryCf": {
+                                                                "description": "Array property in IPs array GeoData object"
+                                                            },
+                                                            "ipAddr": {
+                                                                "description": "Array property in IPs array GeoData object"
+                                                            },
+                                                            "ipRoutingType": {
+                                                                "description": "Array property in IPs array GeoData object"
+                                                            },
+                                                            "latitude": {
+                                                                "description": "Array property in IPs array GeoData object"
+                                                            },
+                                                            "longitude": {
+                                                                "description": "Array property in IPs array GeoData object"
+                                                            },
+                                                            "organization": {
+                                                                "description": "Array property in IPs array GeoData object"
+                                                            },
+                                                            "organizationType": {
+                                                                "description": "Array property in IPs array GeoData object"
+                                                            },
+                                                            "region": {
+                                                                "description": "Array property in IPs array GeoData object"
+                                                            },
+                                                            "state": {
+                                                                "description": "Array property in IPs array GeoData object"
+                                                            },
+                                                            "stateCf": {
+                                                                "description": "Array property in IPs array GeoData object"
+                                                            },
+                                                            "stateCode": {
+                                                                "description": "Array property in IPs array GeoData object"
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    },
+                                                    "RawEntity": {
+                                                        "description": "Object containing Raw unenriched entity data in IPs array",
+                                                        "properties": {
+                                                            "address": {
+                                                                "description": "address from RawEntity object in IPs array"
+                                                            },
+                                                            "friendlyName": {
+                                                                "description": "friendlyName from RawEntity object in IPs array"
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    }
+                                                },
+                                                "required": [],
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        "IPsCount": {
+                                            "description": "Count of IPs processed by module",
+                                            "type": "integer"
+                                        },
+                                        "IncidentARMId": {
+                                            "description": "The ARM Id of the Azure Sentinel Incident",
+                                            "type": "string"
+                                        },
+                                        "URLs": {
+                                            "description": "Array of URLs",
+                                            "items": {
+                                                "properties": {
+                                                    "RawEntity": {
+                                                        "description": "Object containing Raw unenriched entity data in URLs array",
+                                                        "properties": {
+                                                            "friendlyName": {
+                                                                "description": "friendlyName from RawEntity object in URLs array"
+                                                            },
+                                                            "url": {
+                                                                "description": "url from RawEntity object in URLs array"
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    }
+                                                },
+                                                "required": [],
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        "URLsCount": {
+                                            "description": "Count of URLs processed by module",
+                                            "type": "integer"
+                                        },
+                                        "WorkspaceId": {
+                                            "description": "The Log Analytics Workspace Id of the Azure Sentinel Incident",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "Response": {
+                            "runAfter": {
+                                "Condition_-_Comment": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "type": "Response",
+                            "kind": "Http",
+                            "inputs": {
+                                "body": "@body('HTTP_-_Run_Playbook')",
+                                "statusCode": "@variables('responseCode')"
+                            }
+                        },
+                        "Set_Failure_Comment": {
+                            "runAfter": {
+                                "HTTP_-_Run_Playbook": [
+                                    "Failed"
+                                ]
+                            },
+                            "type": "SetVariable",
+                            "inputs": {
+                                "name": "incidentComment",
+                                "value": "The Playbook @{triggerBody()?['PlaybookName']} failed to start on this incident."
+                            }
+                        },
+                        "Set_Success_Comment": {
+                            "runAfter": {
+                                "HTTP_-_Run_Playbook": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "type": "SetVariable",
+                            "inputs": {
+                                "name": "incidentComment",
+                                "value": "The Playbook @{triggerBody()?['PlaybookName']} was successfully started on this incident by the Microsoft Sentinel Triage AssistanT (STAT)"
+                            }
+                        },
+                        "Set_variable_-_responseCode": {
+                            "runAfter": {
+                                "Set_Failure_Comment": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "type": "SetVariable",
+                            "inputs": {
+                                "name": "responseCode",
+                                "value": 500
+                            }
+                        }
+                    },
+                    "outputs": {}
+                },
+                "parameters": {
+                    "$connections": {
+                        "value": {
+                            "azuresentinel": {
+                                "connectionId": "[resourceId('Microsoft.Web/connections', variables('AzureSentinelConnectionName'))]",
+                                "connectionName": "[variables('AzureSentinelConnectionName')]",
+                                "id": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Web/locations/', resourceGroup().location, '/managedApis/azuresentinel')]",
+                                "connectionProperties": {
+                                    "authentication": {
+                                        "type": "ManagedServiceIdentity"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    ],
+    "outputs": {
+        "resourceID": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Logic/workflows', parameters('PlaybookName'))]"
+        }
+    }
+}

--- a/Modules/RunPlaybook/azuredeploy.json
+++ b/Modules/RunPlaybook/azuredeploy.json
@@ -8,8 +8,7 @@
         }
     },
     "variables": {
-        "AzureSentinelConnectionName": "[concat('azuresentinel-', parameters('PlaybookName'))]",
-        "ConversionServiceConnectionName": "[concat('conversionservice-', parameters('PlaybookName'))]"
+        "AzureSentinelConnectionName": "[concat('azuresentinel-', parameters('PlaybookName'))]"
     },
     "resources": [
         {
@@ -33,8 +32,7 @@
             "name": "[parameters('PlaybookName')]",
             "location": "[resourceGroup().location]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/connections', variables('AzureSentinelConnectionName'))]",
-                "[resourceId('Microsoft.Web/connections', variables('ConversionServiceConnectionName'))]"
+                "[resourceId('Microsoft.Web/connections', variables('AzureSentinelConnectionName'))]"
             ],
             "identity": {
                 "type": "SystemAssigned"

--- a/Modules/RunPlaybook/readme.md
+++ b/Modules/RunPlaybook/readme.md
@@ -1,0 +1,36 @@
+# Run-Playbook
+
+## Description
+This module will allow you to start another Microsoft Sentinel playbook on the incident being investigated via STAT. This allows you to benefit from the many existing Playbooks available for Microsoft Sentinel without having to incorporate their Logic into your triage playbooks.
+
+## Suported Entity Types
+* N/A
+
+## Trigger Parameters
+
+|Parameter|Expected Values|Description|
+|---|---|---|
+|AddIncidentComments|True/False (Default:True)|When set to true, the start of the Playbook will be logged to the incident comments|
+|Base Module Body|Body (dynamic content)|The Body should be selected from the Dynamic content of the Base-Module response|
+|LogicAppResourceId|resourceId|The resourceId of the Logic App (Playbook) you want to run against the incident|
+|TenantId|Azure AD Tenant Id|The Azure AD Tenant Id associated with the subscriptions of the Logic App|
+
+## Return Properties
+
+This module does not return a Body unless there is an error, but a status code is always included in the return.
+
+|Status Code|Description|
+|---|---|
+|200|The called playbook successfully started|
+|500|An error caused the called playbook from starting.  This is usually due to the Run-Playbook managed identity not having Microsoft Sentinel Responder on the Sentinel resource groupp or Microsoft Sentinel (Azure Security Insights) not having the Microsoft Sentinel Automation Contributor role on the resource group where the Playbook is located|
+
+## Advanced Deployment
+
+Deployment of the Sentinel Triage AssistanT should typically be performed from the [deployment template](/Deploy/readme.md), however in some cases you may wish to deploy an individual module below.
+
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fbriandelmsft%2FSentinelAutomationModules%2Fmain%2FModules%2FRunPlaybook%2Fazuredeploy.json)
+
+## Post Deployment
+
+* Grant the Logic app Microsoft Sentinel Responder RBAC role on the resource group containing Microsoft Sentinel (GrantPermissions.ps1)
+* Grant Microsoft Sentinel (Azure Security Insights) the Microsoft Sentinel Automation Contributor role on the Resource Groups of the Playbook you want to run

--- a/Modules/RunPlaybook/returnschema.json
+++ b/Modules/RunPlaybook/returnschema.json
@@ -1,0 +1,4 @@
+{
+    "type": "object",
+    "properties": {}
+}

--- a/Modules/readme.md
+++ b/Modules/readme.md
@@ -15,6 +15,8 @@ Automation Modules make it easier to perform routine tasks by using a common set
 * Microsoft Sentinel Threat Intelligence
 * Microsoft Sentinel User Entity Behavior Analytics
 * Microsoft Sentinel Watchlists
+* Risk Scoring
+* Run Playbook
 
 ### Base Module
 
@@ -63,3 +65,7 @@ The Microsoft Sentinel Watchlists module allows you to compare entity data from 
 ### Risk Scoring
 
 The Risk Scoring module takes the output from other STAT modules to calculate a relative risk score.  This score can then be consumed by the calling Logic app to define different outcomes based on the score returned.
+
+### Run Playbook
+
+The Run Playbook module can be used to invoke other Microsoft Sentinel Playbooks.  In situations where you are analyzing an incident using STAT, under certain conditions you may want to initiate other playbooks instead of incorporating the logic of those playbooks into your main STAT triage playbooks.  This module allows you to reuse other playbooks as needed during an incident triage.

--- a/Modules/versions.json
+++ b/Modules/versions.json
@@ -1,6 +1,6 @@
 {
     "AADRisksModule": "0.0.5",
-    "BaseModule": "0.3.1",
+    "BaseModule": "0.4.0",
     "FileModule": "0.0.3",
     "KQLModule": "0.1.3",
     "MCASModule": "0.0.6",

--- a/Modules/versions.json
+++ b/Modules/versions.json
@@ -7,6 +7,7 @@
     "MDEModule": "0.1.2",
     "OOFModule": "0.0.3",
     "RelatedAlerts": "0.1.3",
+    "RunPlaybook": "0.0.1",
     "ScoringModule": "0.0.2",
     "TIModule": "0.1.1",
     "UEBAModule": "0.0.6",


### PR DESCRIPTION
* Fixes #299 
* Fixes #230
* Relates to #297

This PR includes the addition of a new module to allow you to run incident playbooks from STAT.  For example, if you wanted to use STAT to triage an incident and based on the outcome of that triage you could start another playbook that takes additional actions.

This also includes enhancements to the Base Module to retrieve and include SSPR & MFA registration data about the account entities.

[Deploy this PR](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fbriandelmsft%2FSentinelAutomationModules%2Frunplaybook_deploy%2FDeploy%2Fazuredeploy.json/createUIDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2Fbriandelmsft%2FSentinelAutomationModules%2Frunplaybook_deploy%2FDeploy%2FcreateUiDefinition.json)

As this PR changes the deployment itself, after merging into main perform a test deployment from the main branch to confirm a deploy from that branch works as intended