### PR TITLE
Add run id to KQL module output

### DIFF
--- a/Modules/KQLModule/azuredeploy.json
+++ b/Modules/KQLModule/azuredeploy.json
@@ -53,7 +53,7 @@
                             "type": "Object"
                         },
                         "PlaybookVersion": {
-                            "defaultValue": "0.1.3",
+                            "defaultValue": "0.1.4",
                             "type": "String"
                         },
                         "PlaybookInternalName": {
@@ -625,6 +625,7 @@
                             "inputs": {
                                 "body": {
                                     "DetailedResults": "@variables('Records')",
+                                    "LogicAppRunId": "@{workflow()?['run']?['name']}",
                                     "ModuleName": "@{parameters('PlaybookInternalName')}",
                                     "ResultsCount": "@variables('ResultCount')",
                                     "ResultsFound": "@variables('ResultsFound')"

--- a/Modules/KQLModule/readme.md
+++ b/Modules/KQLModule/readme.md
@@ -99,6 +99,7 @@ SecurityIncident
 |Property|Description|
 |---|---|
 |DetailedResults|An array of each record found by the KQL query|
+|LogicAppRunId|Returns the Run id for that instance of the module run history to assist in troubleshooting|
 |ModuleName|The internal Name of the Playbook|
 |ResultsCount|Number of results found by the KQL query|
 |ResultsFound|true/false indicating if results were found by the KQL query|

--- a/Modules/KQLModule/returnschema.json
+++ b/Modules/KQLModule/returnschema.json
@@ -4,6 +4,9 @@
         "DetailedResults": {
             "type": "array"
         },
+        "LogicAppRunId": {
+            "type": "string"
+        },
         "ModuleName": {
             "type": "string"
         },

--- a/Modules/versions.json
+++ b/Modules/versions.json
@@ -2,7 +2,7 @@
     "AADRisksModule": "0.0.5",
     "BaseModule": "0.4.0",
     "FileModule": "0.0.3",
-    "KQLModule": "0.1.3",
+    "KQLModule": "0.1.4",
     "MCASModule": "0.0.6",
     "MDEModule": "0.1.2",
     "OOFModule": "0.0.3",


### PR DESCRIPTION
* Fixes #304

When troubleshooting logic apps with multiple calls to the KQL module, it can be difficult to retrieve the correct run history.  This change returns the run id of the KQL module back to the connector.  I did not add this to the connector parsing as this is really for debug only, so it can only be seen in the raw outputs of the connector.

![image](https://user-images.githubusercontent.com/68655382/187921294-3ba87494-760c-412d-b6fd-d6bf42be3b68.png)
