### PR TITLE
add loop to API detection

### DIFF
--- a/Modules/MCASModule/azuredeploy.json
+++ b/Modules/MCASModule/azuredeploy.json
@@ -86,7 +86,8 @@
                                             "AboveThreholdCount": "@length(body('Filter_scores_above_the_threshold'))",
                                             "AnalyzedEntities": "@length(variables('DetailedResults'))",
                                             "DetailedResults": "@variables('DetailedResults')",
-                                            "MaximumScore": "@max(variables('Scores'))"
+                                            "MaximumScore": "@max(variables('Scores'))",
+                                            "ModuleName": "@{parameters('PlaybookInternalName')}"
                                         },
                                         "runAfter": {
                                             "Filter_scores_above_the_threshold": [
@@ -187,92 +188,137 @@
                         },
                         "Check_if_the_APIURL_is_set": {
                             "actions": {
-                                "For_each_TenantRegions_value": {
+                                "Until": {
                                     "actions": {
-                                        "Check_for_probe's_response": {
+                                        "Condition": {
                                             "actions": {
-                                                "Set_APIURL": {
-                                                    "inputs": {
-                                                        "name": "APIURL",
-                                                        "value": "@{outputs('Compose_URL')}"
-                                                    },
+                                                "Delay": {
                                                     "runAfter": {},
-                                                    "type": "SetVariable"
+                                                    "type": "Wait",
+                                                    "inputs": {
+                                                        "interval": {
+                                                            "count": 10,
+                                                            "unit": "Second"
+                                                        }
+                                                    }
                                                 }
+                                            },
+                                            "runAfter": {
+                                                "For_each_TenantRegions_value": [
+                                                    "Succeeded"
+                                                ]
                                             },
                                             "expression": {
                                                 "and": [
                                                     {
-                                                        "not": {
-                                                            "equals": [
-                                                                "@body('HTTP_Probe_URL')?['detail']",
-                                                                "tenant not found"
-                                                            ]
-                                                        }
-                                                    },
-                                                    {
-                                                        "not": {
-                                                            "equals": [
-                                                                "@body('HTTP_Probe_URL')?['detail']",
-                                                                "tenant is disabled"
-                                                            ]
-                                                        }
-                                                    },
-                                                    {
-                                                        "not": {
-                                                            "equals": [
-                                                                "@body('HTTP_Probe_URL')?['detail']",
-                                                                "Invalid token"
-                                                            ]
-                                                        }
+                                                        "equals": [
+                                                            "@length(variables('APIURL'))",
+                                                            0
+                                                        ]
                                                     }
-                                                ]
-                                            },
-                                            "runAfter": {
-                                                "HTTP_Probe_URL": [
-                                                    "Succeeded",
-                                                    "Failed"
                                                 ]
                                             },
                                             "type": "If"
                                         },
-                                        "Compose_URL": {
-                                            "inputs": "https://@{item()}.portal.cloudappsecurity.com",
+                                        "For_each_TenantRegions_value": {
+                                            "foreach": "@variables('TenantRegions')",
+                                            "actions": {
+                                                "Check_for_probe's_response": {
+                                                    "actions": {
+                                                        "Set_APIURL": {
+                                                            "runAfter": {},
+                                                            "type": "SetVariable",
+                                                            "inputs": {
+                                                                "name": "APIURL",
+                                                                "value": "@{outputs('Compose_URL')}"
+                                                            }
+                                                        }
+                                                    },
+                                                    "runAfter": {
+                                                        "HTTP_Probe_URL": [
+                                                            "Succeeded",
+                                                            "Failed"
+                                                        ]
+                                                    },
+                                                    "expression": {
+                                                        "and": [
+                                                            {
+                                                                "not": {
+                                                                    "equals": [
+                                                                        "@body('HTTP_Probe_URL')?['detail']",
+                                                                        "tenant not found"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            {
+                                                                "not": {
+                                                                    "equals": [
+                                                                        "@body('HTTP_Probe_URL')?['detail']",
+                                                                        "tenant is disabled"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            {
+                                                                "not": {
+                                                                    "equals": [
+                                                                        "@body('HTTP_Probe_URL')?['detail']",
+                                                                        "Invalid token"
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    },
+                                                    "type": "If"
+                                                },
+                                                "Compose_URL": {
+                                                    "runAfter": {},
+                                                    "type": "Compose",
+                                                    "inputs": "https://@{item()}.portal.cloudappsecurity.com"
+                                                },
+                                                "HTTP_Probe_URL": {
+                                                    "runAfter": {
+                                                        "Compose_URL": [
+                                                            "Succeeded"
+                                                        ]
+                                                    },
+                                                    "type": "Http",
+                                                    "inputs": {
+                                                        "authentication": {
+                                                            "audience": "05a65629-4c1b-48c1-a78b-804c4abdd4af",
+                                                            "type": "ManagedServiceIdentity"
+                                                        },
+                                                        "body": {
+                                                            "limit": 1
+                                                        },
+                                                        "method": "POST",
+                                                        "uri": "@{outputs('Compose_URL')}/api/v1/entities/"
+                                                    }
+                                                }
+                                            },
                                             "runAfter": {},
-                                            "type": "Compose"
-                                        },
-                                        "HTTP_Probe_URL": {
-                                            "inputs": {
-                                                "authentication": {
-                                                    "audience": "05a65629-4c1b-48c1-a78b-804c4abdd4af",
-                                                    "type": "ManagedServiceIdentity"
-                                                },
-                                                "body": {
-                                                    "limit": 1
-                                                },
-                                                "method": "POST",
-                                                "uri": "@{outputs('Compose_URL')}/api/v1/entities/"
-                                            },
-                                            "runAfter": {
-                                                "Compose_URL": [
-                                                    "Succeeded"
-                                                ]
-                                            },
-                                            "type": "Http"
+                                            "type": "Foreach",
+                                            "description": "Brute forcing the URL to find the right one without asking the user",
+                                            "runtimeConfiguration": {
+                                                "concurrency": {
+                                                    "repetitions": 20
+                                                }
+                                            }
                                         }
                                     },
-                                    "description": "Brute forcing the URL to find the right one without asking the user",
-                                    "foreach": "@variables('TenantRegions')",
                                     "runAfter": {},
-                                    "runtimeConfiguration": {
-                                        "concurrency": {
-                                            "repetitions": 20
-                                        }
+                                    "expression": "@not(equals(length(variables('APIURL')), 0))",
+                                    "limit": {
+                                        "count": 10,
+                                        "timeout": "PT5M"
                                     },
-                                    "type": "Foreach"
+                                    "type": "Until"
                                 }
                             },
-                            "description": "If not already set, we will enter in a loop to detect the URL in best effort.",
+                            "runAfter": {
+                                "Initialize_TenantRegions_array": [
+                                    "Succeeded"
+                                ]
+                            },
                             "expression": {
                                 "and": [
                                     {
@@ -283,22 +329,19 @@
                                     }
                                 ]
                             },
-                            "runAfter": {
-                                "Initialize_TenantRegions_array": [
-                                    "Succeeded"
-                                ]
-                            },
-                            "type": "If"
+                            "type": "If",
+                            "description": "If not already set, we will enter in a loop to detect the URL in best effort."
                         },
                         "Condition_-_Terminate_if_no_accounts": {
                             "actions": {
                                 "Response_-_No_Account_Entities": {
                                     "inputs": {
                                         "body": {
+                                            "AboveThreholdCount": 0,
                                             "AnalyzedEntities": 0,
                                             "DetailedResults": [],
                                             "MaximumScore": 0,
-                                            "UnderThreholdCount": 0
+                                            "ModuleName": "@{parameters('PlaybookInternalName')}"
                                         },
                                         "statusCode": 200
                                     },
@@ -1037,7 +1080,7 @@
                             "type": "String"
                         },
                         "PlaybookVersion": {
-                            "defaultValue": "0.0.6",
+                            "defaultValue": "0.0.7",
                             "type": "String"
                         },
                         "ProjectName": {

--- a/Modules/MCASModule/readme.md
+++ b/Modules/MCASModule/readme.md
@@ -21,6 +21,7 @@ This module will get the MCAS Investigation Score of the account entities of the
 |AnalysedEntities|Number of entities analyzed|
 |AboveThreholdCount|Number of accounts foud above the specified threshold|
 |MaximumScore|Maximum score found for all entities|
+|ModuleName|The internal Name of the Playbook|
 |DetailedResults|An array of user with their respective score|
 
 ## Sample Return
@@ -36,7 +37,8 @@ This module will get the MCAS Investigation Score of the account entities of the
       "UserPrincipalName": "bob@xontoso.com"
     }
   ],
-  "MaximumScore": 270
+  "MaximumScore": 270,
+  "ModuleName": "MCASModule"
 }
 ```
 

--- a/Modules/MCASModule/returnschema.json
+++ b/Modules/MCASModule/returnschema.json
@@ -30,6 +30,10 @@
         "MaximumScore": {
             "type": "integer",
             "description": "Maximum score found for all entities"
+        },
+        "ModuleName": {
+            "type": "string",
+            "description": "Name of the STAT module"
         }
     }
 }


### PR DESCRIPTION
**This is PR into your patch Branch, not directly to main**

I've done some additional testing, and again, without the loop around the API detection URL I end up failing on the first attempt through after I have not used the module for a period of time.  In this case it was 3 days between the last time it worked and this attempt.

This PR
* Adds an Until loop around the API detection URL, if it works the first time it will not add any delay
* Adds the module name to the output (for later integration in the scoring module)
* Normalized the output between the no entity path and a path that had entity data, output schema was a bit different