### PR TITLE
Update deployment link and risk scoring docs

### DIFF
--- a/Deploy/readme.md
+++ b/Deploy/readme.md
@@ -20,7 +20,7 @@ When upgrading the base module from versions below 0.4.0 to this version or abov
 
 ## Quick Deployment
 
-[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fbriandelmsft%2FSentinelAutomationModules%2Fmain%2FDeploy%2Fazuredeploy.json/createUIDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2Fbriandelmsft%2FSentinelAutomationModules%2Fmain%2FDeploy%2FcreateUiDefinition.json)
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://aka.ms/mstatdeploy)
 
 ## Post Deployment
 

--- a/Docs/deployment.md
+++ b/Docs/deployment.md
@@ -17,7 +17,7 @@ STAT can be deployed/updated via single ARM deployment
 
 ### Deployment Template
 
-[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fbriandelmsft%2FSentinelAutomationModules%2Fmain%2FDeploy%2Fazuredeploy.json/createUIDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2Fbriandelmsft%2FSentinelAutomationModules%2Fmain%2FDeploy%2FcreateUiDefinition.json)
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://aka.ms/mstatdeploy)
 
 ## Post Deloyment
 

--- a/Docs/riskscoring.md
+++ b/Docs/riskscoring.md
@@ -6,10 +6,16 @@ Risk Scoring is a module of STAT that can be used to calculate a cumulative risk
 
 The Risk Scoring module accepts the *Body* output of the following modules as an input:
 
+* AAD Risks Module
+* Microsoft Defender for Endpoint Module
+* Related Alerts Module
 * KQL Module
-* Related Alerts
-* Threat Intel Module
+* Threat Intelligence Module
 * Watchlist Module
+* User Entity Behavior Analytics Module
+* File Module
+* Microsoft Defender for Cloud Apps Module
+* Custom Content Scoring
 
 ## Risk Scoring Example
 


### PR DESCRIPTION
* Switching long link to associated aka.ms
* Updating risk scoring module docs to include the additional supported modules