### PR TITLE
Update Graph API Permission request

### DIFF
--- a/Deploy/GrantPermissions.ps1
+++ b/Deploy/GrantPermissions.ps1
@@ -35,7 +35,7 @@ $LogicAppPrefix = ""                               # Adds a prefix to all Logic 
 
 # Connect to the Microsoft Graph API and Azure Management API
 Write-Host "⚙️ Connect to the Azure AD tenant: $TenantId"
-Connect-MgGraph -TenantId $TenantId -Scopes AppRoleAssignment.ReadWrite.All | Out-Null
+Connect-MgGraph -TenantId $TenantId -Scopes AppRoleAssignment.ReadWrite.All, Application.Read.All | Out-Null
 Write-Host "⚙️ Connecting to  to the Azure subscription: $AzureSubscriptionId"
 try
 {


### PR DESCRIPTION
Added 'Application.Read.All' to the scope of the Graph API call. 

For Azure AD tenants that have not used 'Microsoft Graph Powershell' before the Get-AppIds command within Set-APIPermissions function will fail with an 'Insufficient permissions' error, as the Graph is unable to read App IDs with just 'AppRoleAssignment.ReadWrite.All' alone