### PR TITLE
Include MFA frauds reports where no actions were taken

### DIFF
--- a/Modules/AADRisksModule/azuredeploy.json
+++ b/Modules/AADRisksModule/azuredeploy.json
@@ -360,7 +360,7 @@
                                 "Condition_-_MFA_fraud_lookup": {
                                     "actions": {
                                         "Compose_KQL_for_MFA_frauds": {
-                                            "inputs": "AuditLogs \n| where OperationName == \"Fraud reported - user is blocked for MFA\"\n| where ResultDescription == \"Successfully reported fraud\"\n| extend Id= tostring(parse_json(tostring(InitiatedBy.user)).id)\n| where Id == \"@{item()['id']}\"\n| summarize Count=count() by Id",
+                                            "inputs": "AuditLogs \n| where OperationName in (\"Fraud reported - user is blocked for MFA\",\"Fraud reported - no action taken\")\n| where ResultDescription == \"Successfully reported fraud\"\n| extend Id= tostring(parse_json(tostring(InitiatedBy.user)).id)\n| where Id == \"@{item()['id']}\"\n| summarize Count=count() by Id",
                                             "runAfter": {},
                                             "type": "Compose"
                                         },
@@ -917,7 +917,7 @@
                             "type": "Object"
                         },
                         "PlaybookVersion": {
-                            "defaultValue": "0.0.6",
+                            "defaultValue": "0.0.7",
                             "type": "String"
                         },
                         "PlaybookInternalName": {

--- a/Modules/versions.json
+++ b/Modules/versions.json
@@ -1,5 +1,5 @@
 {
-    "AADRisksModule": "0.0.6",
+    "AADRisksModule": "0.0.7",
     "BaseModule": "0.4.0",
     "FileModule": "0.0.4",
     "KQLModule": "0.1.4",


### PR DESCRIPTION
Fixes #379

Change KQL to include "Fraud reported - no action taken" as such:

```
AuditLogs 
| where OperationName in ("Fraud reported - user is blocked for MFA","Fraud reported - no action taken")
| where ResultDescription == "Successfully reported fraud"
| extend Id= tostring(parse_json(tostring(InitiatedBy.user)).id)
```