### PR TITLE
Fixing incorrect string conversion

### DIFF
--- a/Samples/basicsample.json
+++ b/Samples/basicsample.json
@@ -57,7 +57,7 @@
                             "type": "Object"
                         },
                         "PlaybookVersion": {
-                            "defaultValue": "1.5.0",
+                            "defaultValue": "1.5.6",
                             "type": "String"
                         },
                         "PlaybookInternalName": {
@@ -95,7 +95,7 @@
                             "type": "ApiConnection",
                             "inputs": {
                                 "body": {
-                                    "BaseModuleBody": "@{body('Base_Module')}",
+                                    "BaseModuleBody": "@body('Base_Module')",
                                     "LookbackInDays": 14
                                 },
                                 "host": {
@@ -210,7 +210,7 @@
                             "type": "ApiConnection",
                             "inputs": {
                                 "body": {
-                                    "BaseModuleBody": "@{body('Base_Module')}",
+                                    "BaseModuleBody": "@body('Base_Module')",
                                     "LookbackInDays": 14
                                 },
                                 "host": {
@@ -237,7 +237,7 @@
                             "type": "ApiConnection",
                             "inputs": {
                                 "body": {
-                                    "BaseModuleBody": "@{body('Base_Module')}",
+                                    "BaseModuleBody": "@body('Base_Module')",
                                     "ScoringData": [
                                         {
                                             "ModuleBody": "@body('AAD_Risks_Module')",
@@ -277,7 +277,7 @@
                             "type": "ApiConnection",
                             "inputs": {
                                 "body": {
-                                    "BaseModuleBody": "@{body('Base_Module')}"
+                                    "BaseModuleBody": "@body('Base_Module')"
                                 },
                                 "host": {
                                     "connection": {


### PR DESCRIPTION
* Fixes #425 

Sample template was passing module body as strings instead of objects, causing them to fail parsing.