### PR TITLE
Removing Legacy App Insights

### DIFF
--- a/Deploy/statdeploy.json
+++ b/Deploy/statdeploy.json
@@ -155,26 +155,12 @@
             }
         },
         {
-            "type": "Microsoft.Insights/components",
-            "apiVersion": "2020-02-02",
-            "name": "[variables('functionName')]",
-            "location": "[parameters('location')]",
-            "tags": {
-                "[format('hidden-link:{0}', resourceId('Microsoft.Web/sites', variables('functionName')))]": "Resource"
-            },
-            "properties": {
-                "Application_Type": "web"
-            },
-            "kind": "web"
-        },
-        {
             "condition": "[equals(parameters('identityType'), 'sp')]",
             "apiVersion": "2019-10-01",
             "name": "STATFunctionSP",
             "type": "Microsoft.Resources/deployments",
             "dependsOn": [
                 "[resourceId('Microsoft.Web/serverfarms', variables('functionName'))]",
-                "[resourceId('Microsoft.Insights/components', variables('functionName'))]",
                 "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
             ],
             "properties": {
@@ -251,7 +237,6 @@
             "type": "Microsoft.Resources/deployments",
             "dependsOn": [
                 "[resourceId('Microsoft.Web/serverfarms', variables('functionName'))]",
-                "[resourceId('Microsoft.Insights/components', variables('functionName'))]",
                 "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
             ],
             "properties": {
@@ -322,7 +307,6 @@
             "type": "Microsoft.Resources/deployments",
             "dependsOn": [
                 "[resourceId('Microsoft.Web/serverfarms', variables('functionName'))]",
-                "[resourceId('Microsoft.Insights/components', variables('functionName'))]",
                 "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
             ],
             "properties": {

--- a/Function/ServicePrincipalIdentity.json
+++ b/Function/ServicePrincipalIdentity.json
@@ -119,10 +119,6 @@
                     "linuxFxVersion": "PYTHON|3.10",
                     "appSettings": [
                         {
-                            "name": "APPINSIGHTS_INSTRUMENTATIONKEY",
-                            "value": "[reference(resourceId('Microsoft.Insights/components', parameters('STATFunctionName')), '2015-05-01').InstrumentationKey]"
-                        },
-                        {
                             "name": "AzureWebJobsStorage",
                             "value": "[format('DefaultEndpointsProtocol=https;AccountName={0};EndpointSuffix={1};AccountKey={2}', parameters('STATStorageName'), environment().suffixes.storage, listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('STATStorageName')), '2019-06-01').keys[0].value)]"
                         },

--- a/Function/SystemIdentity.json
+++ b/Function/SystemIdentity.json
@@ -107,10 +107,6 @@
                     "linuxFxVersion": "PYTHON|3.10",
                     "appSettings": [
                         {
-                            "name": "APPINSIGHTS_INSTRUMENTATIONKEY",
-                            "value": "[reference(resourceId('Microsoft.Insights/components', parameters('STATFunctionName')), '2015-05-01').InstrumentationKey]"
-                        },
-                        {
                             "name": "AzureWebJobsStorage",
                             "value": "[format('DefaultEndpointsProtocol=https;AccountName={0};EndpointSuffix={1};AccountKey={2}', parameters('STATStorageName'), environment().suffixes.storage, listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('STATStorageName')), '2019-06-01').keys[0].value)]"
                         },

--- a/Function/UserAssignedIdentity.json
+++ b/Function/UserAssignedIdentity.json
@@ -119,10 +119,6 @@
                     "linuxFxVersion": "PYTHON|3.10",
                     "appSettings": [
                         {
-                            "name": "APPINSIGHTS_INSTRUMENTATIONKEY",
-                            "value": "[reference(resourceId('Microsoft.Insights/components', parameters('STATFunctionName')), '2015-05-01').InstrumentationKey]"
-                        },
-                        {
                             "name": "AzureWebJobsStorage",
                             "value": "[format('DefaultEndpointsProtocol=https;AccountName={0};EndpointSuffix={1};AccountKey={2}', parameters('STATStorageName'), environment().suffixes.storage, listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('STATStorageName')), '2019-06-01').keys[0].value)]"
                         },


### PR DESCRIPTION
Since we are not using App insights and the default deployment included the legacy version, we are going to remove it completely as it can always be added back in later/manually.